### PR TITLE
Consolidate type-level and value-level constructors

### DIFF
--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 152a8259a7c802ff65834af8d12a9c69edcafecafee417320488dfb8eda28f56
+-- hash: 6af4fa75418ff3dd9a7eac69a10434c8e4f7aac6654137940bf772cf8604f99e
 
 name:           aeson-schemas
 version:        1.2.0
@@ -50,6 +50,7 @@ library
       Data.Aeson.Schema.Key
       Data.Aeson.Schema.Show
       Data.Aeson.Schema.TH
+      Data.Aeson.Schema.Type
       Data.Aeson.Schema.Utils.All
       Data.Aeson.Schema.Utils.Invariant
       Data.Aeson.Schema.Utils.Sum

--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6af4fa75418ff3dd9a7eac69a10434c8e4f7aac6654137940bf772cf8604f99e
+-- hash: 0a280b82e6601cb4654595d662ca409cf54c96d31925d0281548019af6a4582d
 
 name:           aeson-schemas
 version:        1.2.0
@@ -69,6 +69,7 @@ library
       aeson >=1.1.2.0 && <1.6
     , base >=4.9 && <5
     , first-class-families >=0.3.0.0 && <0.9
+    , hashable >=1.2.7.0 && <1.4
     , megaparsec >=6.0.0 && <10
     , template-haskell >=2.12.0.0 && <2.17
     , text >=1.2.2.2 && <1.3
@@ -114,6 +115,7 @@ test-suite aeson-schemas-test
     , base >=4.9 && <5
     , deepseq
     , first-class-families >=0.3.0.0 && <0.9
+    , hashable >=1.2.7.0 && <1.4
     , interpolate
     , megaparsec >=6.0.0 && <10
     , raw-strings-qq
@@ -149,6 +151,7 @@ benchmark aeson-schemas-bench
     , criterion
     , deepseq
     , first-class-families >=0.3.0.0 && <0.9
+    , hashable >=1.2.7.0 && <1.4
     , megaparsec >=6.0.0 && <10
     , template-haskell >=2.12.0.0 && <2.17
     , text >=1.2.2.2 && <1.3

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 - aeson >= 1.1.2.0 && < 1.6
 - base >= 4.9 && < 5
 - first-class-families >= 0.3.0.0 && < 0.9
+- hashable >= 1.2.7.0 && < 1.4
 - megaparsec >= 6.0.0 && < 10
 - template-haskell >= 2.12.0.0 && < 2.17
 - text >= 1.2.2.2 && < 1.3

--- a/src/Data/Aeson/Schema.hs
+++ b/src/Data/Aeson/Schema.hs
@@ -27,3 +27,4 @@ module Data.Aeson.Schema
 
 import Data.Aeson.Schema.Internal
 import Data.Aeson.Schema.TH
+import Data.Aeson.Schema.Type

--- a/src/Data/Aeson/Schema/Key.hs
+++ b/src/Data/Aeson/Schema/Key.hs
@@ -7,6 +7,8 @@ Portability :  portable
 Defines a SchemaKey.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -28,9 +30,11 @@ module Data.Aeson.Schema.Key
   ) where
 
 import qualified Data.Aeson as Aeson
+import Data.Hashable (Hashable)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Proxy (Proxy(..))
 import qualified Data.Text as Text
+import GHC.Generics (Generic)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Language.Haskell.TH.Syntax (Lift)
 
@@ -42,7 +46,7 @@ data SchemaKey' s
   | PhantomKey s
     -- ^ A key that doesn't actually exist in the object, but whose content should be parsed from
     -- the current object.
-  deriving (Show, Eq, Lift)
+  deriving (Show, Eq, Generic, Hashable, Lift)
 
 -- | A value-level SchemaKey
 type SchemaKeyV = SchemaKey' String

--- a/src/Data/Aeson/Schema/Key.hs
+++ b/src/Data/Aeson/Schema/Key.hs
@@ -6,25 +6,92 @@ Portability :  portable
 
 Defines a SchemaKey.
 -}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
 
 module Data.Aeson.Schema.Key
-  ( SchemaKey(..)
-  , fromSchemaKey
+  ( SchemaKey'(..)
+  , SchemaKeyV
+  , fromSchemaKeyV
+  , showSchemaKeyV
+  , getContext
+  , toContext
+  , SchemaKey
+  , IsSchemaKey(..)
   , showSchemaKey
   ) where
 
+import qualified Data.Aeson as Aeson
+import qualified Data.HashMap.Strict as HashMap
+import Data.Proxy (Proxy(..))
+import qualified Data.Text as Text
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+import Language.Haskell.TH.Syntax (Lift)
+
+import Data.Aeson.Schema.Utils.Invariant (unreachable)
+
 -- | A key in a JSON object schema.
-data SchemaKey
-  = NormalKey String
-  | PhantomKey String
+data SchemaKey' s
+  = NormalKey s
+  | PhantomKey s
     -- ^ A key that doesn't actually exist in the object, but whose content should be parsed from
     -- the current object.
-  deriving (Show,Eq)
+  deriving (Show, Eq, Lift)
 
-fromSchemaKey :: SchemaKey -> String
-fromSchemaKey (NormalKey key) = key
-fromSchemaKey (PhantomKey key) = key
+-- | A value-level SchemaKey
+type SchemaKeyV = SchemaKey' String
 
-showSchemaKey :: SchemaKey -> String
-showSchemaKey (NormalKey key) = show key
-showSchemaKey (PhantomKey key) = "[" ++ key ++ "]"
+fromSchemaKeyV :: SchemaKeyV -> String
+fromSchemaKeyV (NormalKey key) = key
+fromSchemaKeyV (PhantomKey key) = key
+
+showSchemaKeyV :: SchemaKeyV -> String
+showSchemaKeyV (NormalKey key) = show key
+showSchemaKeyV (PhantomKey key) = "[" ++ key ++ "]"
+
+-- | Given schema `{ key: innerSchema }` for JSON data `{ key: val1 }`, get the JSON
+-- Value that `innerSchema` should parse.
+getContext :: SchemaKeyV -> Aeson.Object -> Aeson.Value
+getContext = \case
+  -- `innerSchema` should parse `val1`
+  NormalKey key -> HashMap.lookupDefault Aeson.Null (Text.pack key)
+  -- `innerSchema` should parse the same object that `key` is in
+  PhantomKey _ -> Aeson.Object
+
+-- | Given JSON data `val` adhering to `innerSchema`, get the JSON object that should be
+-- merged with the outer JSON object.
+toContext :: SchemaKeyV -> Aeson.Value -> Aeson.Object
+toContext = \case
+  -- `val` should be inserted with key `key`
+  NormalKey key -> HashMap.singleton (Text.pack key)
+  -- If `val` is an object, it should be merged with the outer JSON object
+  PhantomKey _ -> \case
+    Aeson.Object o -> o
+    -- `Try` schema could store `Nothing`, which would return `Null`. In this case, there is no
+    -- context to merge
+    Aeson.Null -> mempty
+    v -> unreachable $ "Invalid value for phantom key: " ++ show v
+
+-- | A type-level SchemaKey
+type SchemaKey = SchemaKey' Symbol
+
+class KnownSymbol (FromSchemaKey key) => IsSchemaKey (key :: SchemaKey) where
+  type FromSchemaKey key :: Symbol
+  toSchemaKeyV :: Proxy key -> SchemaKeyV
+
+instance KnownSymbol key => IsSchemaKey ('NormalKey key) where
+  type FromSchemaKey ('NormalKey key) = key
+  toSchemaKeyV _ = NormalKey $ symbolVal $ Proxy @key
+
+instance KnownSymbol key => IsSchemaKey ('PhantomKey key) where
+  type FromSchemaKey ('PhantomKey key) = key
+  toSchemaKeyV _ = PhantomKey $ symbolVal $ Proxy @key
+
+showSchemaKey :: forall key. IsSchemaKey key => String
+showSchemaKey = showSchemaKeyV $ toSchemaKeyV $ Proxy @key

--- a/src/Data/Aeson/Schema/Show.hs
+++ b/src/Data/Aeson/Schema/Show.hs
@@ -11,13 +11,11 @@ Utilities for showing a schema. Meant to be imported qualified.
 module Data.Aeson.Schema.Show
   ( SchemaType(..)
   , showSchemaType
-    -- * Re-exports
-  , SchemaKey(..)
   ) where
 
 import Data.List (intercalate)
 
-import Data.Aeson.Schema.Key (SchemaKey(..), showSchemaKey)
+import Data.Aeson.Schema.Key (SchemaKeyV, showSchemaKeyV)
 
 -- | 'Data.Aeson.Schema.Internal.SchemaType', but for printing.
 data SchemaType
@@ -25,7 +23,7 @@ data SchemaType
   | SchemaMaybe SchemaType
   | SchemaTry SchemaType
   | SchemaList SchemaType
-  | SchemaObject [(SchemaKey, SchemaType)]
+  | SchemaObject [(SchemaKeyV, SchemaType)]
   | SchemaUnion [SchemaType]
   deriving (Show,Eq)
 
@@ -46,6 +44,6 @@ showSchemaType schema = case schema of
       SchemaList inner -> "List " ++ showSchemaType' inner
       SchemaUnion schemas -> "( " ++ mapJoin showSchemaType' " | " schemas ++ " )"
       SchemaObject pairs -> "{ " ++ mapJoin showPair ", " pairs ++ " }"
-    showPair (key, inner) = showSchemaKey key ++ ": " ++ showSchemaType' inner
+    showPair (key, inner) = showSchemaKeyV key ++ ": " ++ showSchemaType' inner
 
     mapJoin f delim = intercalate delim . map f

--- a/src/Data/Aeson/Schema/TH/Get.hs
+++ b/src/Data/Aeson/Schema/TH/Get.hs
@@ -24,7 +24,7 @@ import Language.Haskell.TH.Syntax (lift)
 
 import Data.Aeson.Schema.Internal (getKey)
 import Data.Aeson.Schema.TH.Parse
-    (GetterExp(..), GetterOperation(..), GetterOps, getterExp, parse)
+    (GetterExp(..), GetterOperation(..), GetterOps, parseGetterExp)
 import Data.Aeson.Schema.Utils.Sum (fromSumType)
 
 -- | Defines a QuasiQuoter for extracting JSON data.
@@ -81,7 +81,7 @@ import Data.Aeson.Schema.Utils.Sum (fromSumType)
 --   the sum type contains an 'Int'.
 get :: QuasiQuoter
 get = QuasiQuoter
-  { quoteExp = parse getterExp >=> generateGetterExp
+  { quoteExp = parseGetterExp >=> generateGetterExp
   , quoteDec = error "Cannot use `get` for Dec"
   , quoteType = error "Cannot use `get` for Type"
   , quotePat = error "Cannot use `get` for Pat"

--- a/src/Data/Aeson/Schema/TH/Getter.hs
+++ b/src/Data/Aeson/Schema/TH/Getter.hs
@@ -17,7 +17,7 @@ import Data.Maybe (isNothing)
 import Language.Haskell.TH
 
 import Data.Aeson.Schema.TH.Get (generateGetterExp)
-import Data.Aeson.Schema.TH.Parse (GetterExp(..), getterExp, parse)
+import Data.Aeson.Schema.TH.Parse (GetterExp(..), parseGetterExp)
 import Data.Aeson.Schema.TH.Utils (reifySchema, unwrapType)
 
 -- | A helper that generates a 'Data.Aeson.Schema.TH.get' expression and a type alias for the result
@@ -67,7 +67,7 @@ mkGetter :: String -> String -> Name -> String -> DecsQ
 mkGetter unwrapName funcName startSchemaName ops = do
   startSchemaType <- reifySchema startSchemaName
 
-  getterExp'@GetterExp{..} <- parse getterExp ops
+  getterExp'@GetterExp{..} <- parseGetterExp ops
   unless (isNothing start) $
     fail $ "Getter expression should start with '.': " ++ ops
 

--- a/src/Data/Aeson/Schema/TH/Parse.hs
+++ b/src/Data/Aeson/Schema/TH/Parse.hs
@@ -26,8 +26,6 @@ import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
-import Data.Aeson.Schema.TH.Utils (GetterOperation(..), GetterOps)
-
 type Parser = Parsec Void String
 
 #if !MIN_VERSION_megaparsec(7,0,0)
@@ -39,6 +37,18 @@ parse :: MonadFail m => Parser a -> String -> m a
 parse parser s = either (fail . errorBundlePretty) return $ runParser parser s s
 
 {- Parser primitives -}
+
+type GetterOps = [GetterOperation]
+
+data GetterOperation
+  = GetterKey String
+  | GetterList [GetterOps] -- ^ Invariant: needs to be non-empty
+  | GetterTuple [GetterOps] -- ^ Invariant: needs to be non-empty
+  | GetterBang
+  | GetterMapList
+  | GetterMapMaybe
+  | GetterBranch Int
+  deriving (Show)
 
 parseGetterOp :: Parser GetterOperation
 parseGetterOp = choice

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -23,12 +23,12 @@ import Data.Text (Text)
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 
-import Data.Aeson.Schema.Internal (Schema(..), SchemaType(..), ToSchemaObject)
 import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV, fromSchemaKeyV)
-import qualified Data.Aeson.Schema.Show as SchemaShow
 import Data.Aeson.Schema.TH.Parse
 import Data.Aeson.Schema.TH.Utils
     (parseSchemaType, schemaPairsToTypeQ, typeQListToTypeQ, typeToSchemaPairs)
+import Data.Aeson.Schema.Type
+    (Schema'(..), SchemaType'(..), ToSchemaObject, showSchemaTypeV)
 
 -- | Defines a QuasiQuoter for writing schemas.
 --
@@ -139,7 +139,7 @@ toParts = \case
       PhantomKey _ -> do
         let schemaTypeShow = parseSchemaType schemaType
         unless (isValidPhantomSchema schemaTypeShow) $
-          fail $ "Invalid schema for '" ++ fromSchemaKeyV schemaKey ++ "': " ++ SchemaShow.showSchemaType schemaTypeShow
+          fail $ "Invalid schema for '" ++ fromSchemaKeyV schemaKey ++ "': " ++ showSchemaTypeV schemaTypeShow
       _ -> return ()
 
     pure . tagAs Provided $ [(schemaKey, pure schemaType)]
@@ -156,10 +156,10 @@ toParts = \case
       SchemaDefObjKeyPhantom key -> PhantomKey key
     -- should return true if it's at all possible to get a valid parse
     isValidPhantomSchema = \case
-      SchemaShow.SchemaMaybe inner -> isValidPhantomSchema inner
-      SchemaShow.SchemaTry _ -> True -- even if inner is a non-object schema, it'll still parse to be Nothing
-      SchemaShow.SchemaUnion schemas -> any isValidPhantomSchema schemas
-      SchemaShow.SchemaObject _ -> True
+      SchemaMaybe inner -> isValidPhantomSchema inner
+      SchemaTry _ -> True -- even if inner is a non-object schema, it'll still parse to be Nothing
+      SchemaUnion schemas -> any isValidPhantomSchema schemas
+      SchemaObject _ -> True
       _ -> False
 
 -- | Resolve the parts returned by 'toParts' as such:

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -12,6 +12,7 @@ The 'schema' quasiquoter.
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.Aeson.Schema.TH.Schema (schema) where
 
@@ -26,7 +27,12 @@ import Language.Haskell.TH.Quote (QuasiQuoter(..))
 import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV, fromSchemaKeyV)
 import Data.Aeson.Schema.TH.Parse
 import Data.Aeson.Schema.TH.Utils
-    (parseSchemaType, schemaPairsToTypeQ, typeQListToTypeQ, typeToSchemaPairs)
+    ( parseSchemaType
+    , schemaPairsToTypeQ
+    , stripSigs
+    , typeQListToTypeQ
+    , typeToSchemaPairs
+    )
 import Data.Aeson.Schema.Type
     (Schema'(..), SchemaType'(..), ToSchemaObject, showSchemaTypeV)
 
@@ -146,7 +152,7 @@ toParts = \case
   SchemaDefObjExtend other -> do
     name <- getName other
     reify name >>= \case
-      TyConI (TySynD _ _ (AppT (PromotedT ty) inner)) | ty == 'Schema ->
+      TyConI (TySynD _ _ (stripSigs -> AppT (PromotedT ty) inner)) | ty == 'Schema ->
         pure . tagAs Imported . map (second pure) $ typeToSchemaPairs inner
       _ -> fail $ "'" ++ show name ++ "' is not a Schema"
   where

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -26,6 +26,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter(..))
 
 import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV, fromSchemaKeyV)
 import Data.Aeson.Schema.TH.Parse
+    (SchemaDef(..), SchemaDefObjItem(..), SchemaDefObjKey(..), parseSchemaDef)
 import Data.Aeson.Schema.TH.Utils
     ( parseSchemaType
     , schemaPairsToTypeQ
@@ -96,7 +97,7 @@ schema :: QuasiQuoter
 schema = QuasiQuoter
   { quoteExp = error "Cannot use `schema` for Exp"
   , quoteDec = error "Cannot use `schema` for Dec"
-  , quoteType = parse schemaDef >=> \case
+  , quoteType = parseSchemaDef >=> \case
       SchemaDefObj items -> [t| 'Schema $(generateSchemaObject items) |]
       _ -> fail "`schema` definition must be an object"
   , quotePat = error "Cannot use `schema` for Pat"

--- a/src/Data/Aeson/Schema/TH/Unwrap.hs
+++ b/src/Data/Aeson/Schema/TH/Unwrap.hs
@@ -14,7 +14,7 @@ import Control.Monad ((>=>))
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 
-import Data.Aeson.Schema.TH.Parse (UnwrapSchema(..), parse, unwrapSchema)
+import Data.Aeson.Schema.TH.Parse (UnwrapSchema(..), parseUnwrapSchema)
 import Data.Aeson.Schema.TH.Utils (reifySchema, unwrapType)
 
 -- | Defines a QuasiQuoter to extract a schema within the given schema.
@@ -52,7 +52,7 @@ unwrap :: QuasiQuoter
 unwrap = QuasiQuoter
   { quoteExp = error "Cannot use `unwrap` for Exp"
   , quoteDec = error "Cannot use `unwrap` for Dec"
-  , quoteType = parse unwrapSchema >=> generateUnwrapSchema
+  , quoteType = parseUnwrapSchema >=> generateUnwrapSchema
   , quotePat = error "Cannot use `unwrap` for Pat"
   }
 

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -5,7 +5,6 @@ Stability   :  experimental
 Portability :  portable
 -}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -15,13 +14,12 @@ module Data.Aeson.Schema.TH.Utils where
 
 import Control.Monad ((>=>))
 import Data.Bifunctor (bimap, first, second)
-import Data.List (intercalate)
 import GHC.Stack (HasCallStack)
 import Language.Haskell.TH
-import Language.Haskell.TH.Syntax (Lift)
 
 import Data.Aeson.Schema.Internal (Object, SchemaResult)
 import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV, fromSchemaKeyV)
+import Data.Aeson.Schema.TH.Parse (GetterOperation(..), GetterOps)
 import Data.Aeson.Schema.Type
     (Schema'(..), SchemaType'(..), SchemaTypeV, showSchemaTypeV)
 
@@ -157,29 +155,3 @@ unwrapType keepFunctor getterOps schemaType =
     withFunctor f = if keepFunctor then appT f else id
 
     showSchemaType = showSchemaTypeV . parseSchemaType
-
-{- GetterOps -}
-
-type GetterOps = [GetterOperation]
-
-data GetterOperation
-  = GetterKey String
-  | GetterList [GetterOps] -- ^ Invariant: needs to be non-empty
-  | GetterTuple [GetterOps] -- ^ Invariant: needs to be non-empty
-  | GetterBang
-  | GetterMapList
-  | GetterMapMaybe
-  | GetterBranch Int
-  deriving (Show,Lift)
-
-showGetterOps :: GetterOps -> String
-showGetterOps = concatMap showGetterOp
-  where
-    showGetterOp = \case
-      GetterKey key -> '.':key
-      GetterList elems -> ".[" ++ intercalate "," (map showGetterOps elems) ++ "]"
-      GetterTuple elems -> ".(" ++ intercalate "," (map showGetterOps elems) ++ ")"
-      GetterBang -> "!"
-      GetterMapList -> "[]"
-      GetterMapMaybe -> "?"
-      GetterBranch x -> '@' : show x

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -10,57 +10,130 @@ Portability :  portable
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
 
-module Data.Aeson.Schema.TH.Utils where
+module Data.Aeson.Schema.TH.Utils
+  ( reifySchema
+  , reifySchemaName
+  , schemaVToTypeQ
+  , schemaTypeVToTypeQ
+  ) where
 
-import Control.Monad ((>=>))
-import Data.Bifunctor (bimap, first, second)
-import GHC.Stack (HasCallStack)
+import Control.Monad (forM, (>=>))
+import Data.Bifunctor (bimap)
+import Data.Text (Text)
 import Language.Haskell.TH
 
-import Data.Aeson.Schema.Internal (Object, SchemaResult)
-import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV, fromSchemaKeyV)
-import Data.Aeson.Schema.TH.Parse (GetterOperation(..), GetterOps)
+import Data.Aeson.Schema.Internal (Object)
+import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV)
 import Data.Aeson.Schema.Type
-    (Schema'(..), SchemaType'(..), SchemaTypeV, showSchemaTypeV)
+    ( Schema'(..)
+    , SchemaObjectMapV
+    , SchemaType'(..)
+    , SchemaTypeV
+    , SchemaV
+    , fromSchemaV
+    )
 
-parseSchemaType :: HasCallStack => Type -> SchemaTypeV
-parseSchemaType = \case
-  AppT (PromotedT name) (ConT inner)
-    | name == 'SchemaScalar -> SchemaScalar $ nameBase inner
-  AppT (PromotedT name) inner
-    | name == 'SchemaMaybe -> SchemaMaybe $ parseSchemaType inner
-    | name == 'SchemaTry -> SchemaTry $ parseSchemaType inner
-    | name == 'SchemaList -> SchemaList $ parseSchemaType inner
-    | name == 'SchemaUnion -> SchemaUnion $ map parseSchemaType $ typeToList inner
-    | name == 'SchemaObject -> SchemaObject $ fromPairs inner
-  ty -> error $ "Unknown type: " ++ show ty
+reifySchema :: String -> Q SchemaV
+reifySchema name = lookupTypeName name >>= maybe unknownSchemaErr reifySchemaName
   where
-    fromPairs pairs = map (second parseSchemaType) $ typeToSchemaPairs pairs
+    unknownSchemaErr = fail $ "Unknown schema: " ++ name
 
-typeToList :: HasCallStack => Type -> [Type]
-typeToList = \case
-  PromotedNilT -> []
-  AppT (AppT PromotedConsT x) xs -> x : typeToList xs
-  SigT ty _ -> typeToList ty
-  ty -> error $ "Not a type-level list: " ++ show ty
+reifySchemaName :: Name -> Q SchemaV
+reifySchemaName = reifySchemaType >=> parseSchema
+  where
+    reifySchemaType :: Name -> Q TypeWithoutKinds
+    reifySchemaType schemaName = reify schemaName >>= \case
+      -- reify `type MySchema = 'Schema '[ ... ]`
+      TyConI (TySynD _ _ (stripKinds -> ty))
+        | AppT (PromotedT name) _ <- ty
+        , name == 'Schema
+        -> return ty
 
-typeToPair :: HasCallStack => Type -> (Type, Type)
-typeToPair = \case
-  AppT (AppT (PromotedTupleT 2) a) b -> (a, b)
-  SigT ty _ -> typeToPair ty
-  ty -> error $ "Not a type-level pair: " ++ show ty
+      -- reify `type MySchema = Object OtherSchema`
+      TyConI (TySynD _ _ (stripKinds -> ty))
+        | AppT (ConT name) (ConT schemaName') <- ty
+        , name == ''Object
+        -> reifySchemaType schemaName'
 
-typeToSchemaPairs :: HasCallStack => Type -> [(SchemaKeyV, Type)]
-typeToSchemaPairs = map (bimap parseSchemaKey stripKinds . typeToPair) . typeToList
+      _ -> fail $ "'" ++ show schemaName ++ "' is not a Schema"
 
-parseSchemaKey :: HasCallStack => Type -> SchemaKeyV
-parseSchemaKey = \case
-  AppT (PromotedT ty) (LitT (StrTyLit key))
-    | ty == 'NormalKey -> NormalKey key
-    | ty == 'PhantomKey -> PhantomKey key
-  SigT ty _ -> parseSchemaKey ty
-  ty -> error $ "Could not parse a schema key: " ++ show ty
+    parseSchema :: TypeWithoutKinds -> Q SchemaV
+    parseSchema ty = maybe (fail $ "Could not parse schema: " ++ show ty) return $ do
+      schemaObjectType <- case ty of
+        AppT (PromotedT name) schemaType | name == 'Schema -> Just schemaType
+        _ -> Nothing
+
+      Schema <$> parseSchemaObjectType schemaObjectType
+
+    parseSchemaObjectType :: TypeWithoutKinds -> Maybe SchemaObjectMapV
+    parseSchemaObjectType schemaObjectType = do
+      schemaObjectListOfPairs <- mapM typeToPair =<< typeToList schemaObjectType
+      forM schemaObjectListOfPairs $ \(schemaKeyType, schemaTypeType) -> do
+        schemaKey <- parseSchemaKey schemaKeyType
+        schemaType <- parseSchemaType schemaTypeType
+        Just (schemaKey, schemaType)
+
+    parseSchemaKey :: TypeWithoutKinds -> Maybe SchemaKeyV
+    parseSchemaKey = \case
+      AppT (PromotedT ty) (LitT (StrTyLit key))
+        | ty == 'NormalKey -> Just $ NormalKey key
+        | ty == 'PhantomKey -> Just $ PhantomKey key
+      _ -> Nothing
+
+    parseSchemaType :: TypeWithoutKinds -> Maybe SchemaTypeV
+    parseSchemaType = \case
+      AppT (PromotedT name) (ConT inner)
+        | name == 'SchemaScalar -> Just $ SchemaScalar $ nameBase inner
+
+      AppT (PromotedT name) inner
+        | name == 'SchemaMaybe  -> SchemaMaybe <$> parseSchemaType inner
+
+        | name == 'SchemaTry    -> SchemaTry <$> parseSchemaType inner
+
+        | name == 'SchemaList   -> SchemaList <$> parseSchemaType inner
+
+        | name == 'SchemaUnion  -> do
+            schemas <- typeToList inner
+            SchemaUnion <$> mapM parseSchemaType schemas
+
+        | name == 'SchemaObject -> SchemaObject <$> parseSchemaObjectType inner
+
+      _ -> Nothing
+
+schemaVToTypeQ :: SchemaV -> TypeQ
+schemaVToTypeQ = appT [t| 'Schema |] . schemaObjectMapVToTypeQ . fromSchemaV
+
+schemaObjectMapVToTypeQ :: SchemaObjectMapV -> TypeQ
+schemaObjectMapVToTypeQ = promotedListT . map schemaObjectPairVToTypeQ
+  where
+    schemaObjectPairVToTypeQ :: (SchemaKeyV, SchemaTypeV) -> TypeQ
+    schemaObjectPairVToTypeQ = promotedPairT . bimap schemaKeyVToTypeQ schemaTypeVToTypeQ
+
+    schemaKeyVToTypeQ :: SchemaKeyV -> TypeQ
+    schemaKeyVToTypeQ = \case
+      NormalKey key  -> [t| 'NormalKey $(litT $ strTyLit key) |]
+      PhantomKey key -> [t| 'PhantomKey $(litT $ strTyLit key) |]
+
+schemaTypeVToTypeQ :: SchemaTypeV -> TypeQ
+schemaTypeVToTypeQ = \case
+  -- some hardcoded cases
+  SchemaScalar "Bool"   -> [t| 'SchemaScalar Bool |]
+  SchemaScalar "Int"    -> [t| 'SchemaScalar Int |]
+  SchemaScalar "Double" -> [t| 'SchemaScalar Double |]
+  SchemaScalar "Text"   -> [t| 'SchemaScalar Text |]
+  SchemaScalar other    -> [t| 'SchemaScalar $(getType other) |]
+  SchemaMaybe inner     -> [t| 'SchemaMaybe $(schemaTypeVToTypeQ inner) |]
+  SchemaTry inner       -> [t| 'SchemaTry $(schemaTypeVToTypeQ inner) |]
+  SchemaList inner      -> [t| 'SchemaList $(schemaTypeVToTypeQ inner) |]
+  SchemaUnion schemas   -> [t| 'SchemaUnion $(promotedListT $ map schemaTypeVToTypeQ schemas) |]
+  SchemaObject pairs    -> [t| 'SchemaObject $(schemaObjectMapVToTypeQ pairs) |]
+  where
+    getType :: String -> TypeQ
+    getType ty = maybe (fail $ "Unknown type: " ++ ty) conT =<< lookupTypeName ty
+
+{- TH utilities -}
 
 -- | Same as 'Type' except without any kind signatures or applications at any depth.
 --
@@ -109,71 +182,22 @@ stripKinds ty =
     LitT _           -> ty
     WildCardT        -> ty
 
--- | Reify the given name and return the result if it reifies to a Schema.
-reifySchema :: Name -> TypeQ
-reifySchema = reify >=> \case
-  TyConI (TySynD _ _ tyWithSigs)
-    | ty <- stripKinds tyWithSigs
-    , AppT (PromotedT name) _ <- ty
-    , name == 'Schema
-    -> pure ty
+typeToList :: TypeWithoutKinds -> Maybe [TypeWithoutKinds]
+typeToList = \case
+  PromotedNilT -> Just []
+  AppT (AppT PromotedConsT x) xs -> (x:) <$> typeToList xs
+  _ -> Nothing
 
-  -- also reify (Object schema)
-  TyConI (TySynD _ _ tyWithSigs)
-    | ty <- stripKinds tyWithSigs
-    , AppT (ConT name) (ConT schema) <- ty
-    , name == ''Object
-    -> reifySchema schema
+typeToPair :: TypeWithoutKinds -> Maybe (TypeWithoutKinds, TypeWithoutKinds)
+typeToPair = \case
+  AppT (AppT (PromotedTupleT 2) a) b -> Just (a, b)
+  _ -> Nothing
 
-  info -> fail $ "Unknown reified schema: " ++ show info
-
--- | Unwrap the given type using the given getter operations.
---
--- Accepts Bool for whether to maintain functor structure (True) or strip away functor applications
--- (False).
-unwrapType :: Bool -> GetterOps -> Type -> TypeQ
-unwrapType keepFunctor getterOps schemaType =
-  case schemaType of
-    AppT (PromotedT ty) inner | ty == 'Schema -> go (AppT (PromotedT 'SchemaObject) inner) getterOps
-    ty -> fail $ "Tried to unwrap something that wasn't a Schema: " ++ show ty
+promotedListT :: [TypeQ] -> TypeQ
+promotedListT = foldr consT promotedNilT
   where
-    go schema [] = [t| SchemaResult $(pure schema) |]
-    go schema (op:ops) = case schema of
-      AppT (PromotedT ty) inner ->
-        case op of
-          GetterKey key | ty == 'SchemaObject ->
-            let getObjectSchema = map (first getSchemaKey . typeToPair) . typeToList
-                getSchemaKey = fromSchemaKeyV . parseSchemaKey
-            in case lookup key (getObjectSchema inner) of
-              Just nextSchema -> go nextSchema ops
-              Nothing -> fail $ "Key '" ++ key ++ "' does not exist in schema: " ++ showSchemaType schema
-          GetterKey key -> fail $ "Cannot get key '" ++ key ++ "' in schema: " ++ showSchemaType schema
-          GetterList elems | ty == 'SchemaObject -> do
-            elemSchemas <- mapM (go schema) elems
-            if all (== head elemSchemas) elemSchemas
-              then appT listT (pure $ head elemSchemas)
-              else fail $ "List contains different types with schema: " ++ showSchemaType schema
-          GetterList _ -> fail $ "Cannot get keys in schema: " ++ showSchemaType schema
-          GetterTuple elems | ty == 'SchemaObject ->
-            foldl appT (tupleT $ length elems) $ map (go schema) elems
-          GetterTuple _ -> fail $ "Cannot get keys in schema: " ++ showSchemaType schema
-          GetterBang | ty == 'SchemaMaybe -> go inner ops
-          GetterBang | ty == 'SchemaTry -> go inner ops
-          GetterBang -> fail $ "Cannot use `!` operator on schema: " ++ showSchemaType schema
-          GetterMapMaybe | ty == 'SchemaMaybe -> withFunctor [t| Maybe |] $ go inner ops
-          GetterMapMaybe | ty == 'SchemaTry -> withFunctor [t| Maybe |] $ go inner ops
-          GetterMapMaybe -> fail $ "Cannot use `?` operator on schema: " ++ showSchemaType schema
-          GetterMapList | ty == 'SchemaList -> withFunctor (pure ListT) $ go inner ops
-          GetterMapList -> fail $ "Cannot use `[]` operator on schema: " ++ showSchemaType schema
-          GetterBranch branch | ty == 'SchemaUnion ->
-            let subTypes = typeToList inner
-            in if branch >= length subTypes
-              then fail $ "Branch out of bounds for schema: " ++ showSchemaType schema
-              else go (subTypes !! branch) ops
-          GetterBranch _ -> fail $ "Cannot use `@` operator on schema: " ++ showSchemaType schema
+    -- nb. https://stackoverflow.com/a/34457936
+    consT x xs = appT (appT promotedConsT x) xs
 
-      _ -> fail $ unlines ["Cannot get type:", show schema, show op]
-
-    withFunctor f = if keepFunctor then appT f else id
-
-    showSchemaType = showSchemaTypeV . parseSchemaType
+promotedPairT :: (TypeQ, TypeQ) -> TypeQ
+promotedPairT (a, b) = [t| '( $a, $b ) |]

--- a/src/Data/Aeson/Schema/Type.hs
+++ b/src/Data/Aeson/Schema/Type.hs
@@ -1,0 +1,82 @@
+{-|
+Module      :  Data.Aeson.Schema.Type
+Maintainer  :  Brandon Chinn <brandon@leapyear.io>
+Stability   :  experimental
+Portability :  portable
+
+Defines SchemaType, the AST that defines a JSON schema.
+-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+
+module Data.Aeson.Schema.Type
+  ( Schema'(..)
+  , SchemaType'(..)
+  , SchemaV
+  , SchemaTypeV
+  , showSchemaTypeV
+  , Schema
+  , SchemaType
+  , ToSchemaObject
+  , FromSchema
+  ) where
+
+import Data.Kind (Type)
+import Data.List (intercalate)
+import GHC.TypeLits (Symbol)
+import Language.Haskell.TH.Syntax (Lift)
+
+import Data.Aeson.Schema.Key (SchemaKey', showSchemaKeyV)
+
+-- | The schema definition for a JSON object.
+data Schema' s ty = Schema (SchemaObjectMap' s ty)
+
+-- | The AST defining a JSON schema.
+data SchemaType' s ty
+  = SchemaScalar ty
+  | SchemaMaybe (SchemaType' s ty)
+  | SchemaTry (SchemaType' s ty) -- ^ @since v1.2.0
+  | SchemaList (SchemaType' s ty)
+  | SchemaUnion [SchemaType' s ty] -- ^ @since v1.1.0
+  | SchemaObject (SchemaObjectMap' s ty)
+  deriving (Show, Eq, Lift)
+
+type SchemaObjectMap' s ty = [(SchemaKey' s, SchemaType' s ty)]
+
+-- | Value-level schema types.
+type SchemaV = Schema' String String
+type SchemaTypeV = SchemaType' String String
+
+-- | Pretty show the given SchemaType.
+showSchemaTypeV :: SchemaTypeV -> String
+showSchemaTypeV schema = case schema of
+  SchemaScalar s -> "SchemaScalar " ++ s
+  SchemaMaybe inner -> "SchemaMaybe " ++ showSchemaTypeV' inner
+  SchemaTry inner -> "SchemaTry " ++ showSchemaTypeV' inner
+  SchemaList inner -> "SchemaList " ++ showSchemaTypeV' inner
+  SchemaUnion _ -> "SchemaUnion " ++ showSchemaTypeV' schema
+  SchemaObject _ -> "SchemaObject " ++ showSchemaTypeV' schema
+  where
+    showSchemaTypeV' = \case
+      SchemaScalar s -> s
+      SchemaMaybe inner -> "Maybe " ++ showSchemaTypeV' inner
+      SchemaTry inner -> "Try " ++ showSchemaTypeV' inner
+      SchemaList inner -> "List " ++ showSchemaTypeV' inner
+      SchemaUnion schemas -> "( " ++ mapJoin showSchemaTypeV' " | " schemas ++ " )"
+      SchemaObject pairs -> "{ " ++ mapJoin showPair ", " pairs ++ " }"
+    showPair (key, inner) = showSchemaKeyV key ++ ": " ++ showSchemaTypeV' inner
+
+    mapJoin f delim = intercalate delim . map f
+
+-- | Type-level schema types.
+type Schema = Schema' Symbol Type
+type SchemaType = SchemaType' Symbol Type
+type SchemaObjectMap = SchemaObjectMap' Symbol Type
+
+type family ToSchemaObject (schema :: Schema) :: SchemaType where
+  ToSchemaObject ('Schema schema) = 'SchemaObject schema
+
+type family FromSchema (schema :: Schema) :: SchemaObjectMap where
+  FromSchema ('Schema schema) = schema

--- a/test/TestUtils/Arbitrary.hs
+++ b/test/TestUtils/Arbitrary.hs
@@ -38,7 +38,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter(quoteType))
 import Test.QuickCheck
 
 import Data.Aeson.Schema (Object, schema)
-import Data.Aeson.Schema.Internal (IsSchemaType)
+import Data.Aeson.Schema.Internal (HasSchemaResult)
 import Data.Aeson.Schema.Key
     (IsSchemaKey(..), SchemaKey, SchemaKey'(..), SchemaKeyV, toContext)
 import Data.Aeson.Schema.Type
@@ -98,7 +98,7 @@ forAllArbitraryObjects = [| \runTest ->
 
 genSchema' :: forall schema.
   ( ArbitrarySchema ('SchemaObject schema)
-  , IsSchemaType ('SchemaObject schema)
+  , HasSchemaResult ('SchemaObject schema)
   )
   => Proxy (Object ('Schema schema)) -> SchemaTypeV -> Gen ArbitraryObject
 genSchema' proxy schemaType = do

--- a/test/Tests/SchemaQQ.hs
+++ b/test/Tests/SchemaQQ.hs
@@ -158,10 +158,10 @@ testInvalidSchemas = testGroup "Invalid schemas"
       [schemaErr| { #Int } |] @?= "'GHC.Types.Int' is not a Schema"
 
   , testCase "Object importing an unknown schema" $
-      [schemaErr| { foo: #FooSchema } |] @?= "Unknown type: FooSchema"
+      [schemaErr| { foo: #FooSchema } |] @?= "Unknown schema: FooSchema"
 
   , testCase "Object extending an unknown schema" $
-      [schemaErr| { #FooSchema } |] @?= "Unknown type: FooSchema"
+      [schemaErr| { #FooSchema } |] @?= "Unknown schema: FooSchema"
 
   , testCase "Object with a phantom key for a scalar" $
       [schemaErr| { [a]: Int } |] @?= "Invalid schema for 'a': SchemaScalar Int"

--- a/test/Tests/SchemaQQ/TH.hs
+++ b/test/Tests/SchemaQQ/TH.hs
@@ -40,7 +40,7 @@ qState = QState
       , ("Tests.SchemaQQ.TH.ExtraSchema", ''ExtraSchema)
       , ("Int", ''Int)
       ]
-  , reifyInfo = $(loadNames [''ExtraSchema, ''ExtraSchema2, ''Int])
+  , reifyInfo = $(loadNames [''UserSchema, ''ExtraSchema, ''ExtraSchema2, ''Int])
   }
 
 -- | A quasiquoter for generating the string representation of a schema.

--- a/test/Tests/SchemaQQ/TH.hs
+++ b/test/Tests/SchemaQQ/TH.hs
@@ -13,7 +13,8 @@ import Language.Haskell.TH.TestUtils
     (MockedMode(..), QMode(..), QState(..), loadNames, runTestQ, runTestQErr)
 
 import Data.Aeson.Schema (schema)
-import Data.Aeson.Schema.Internal (ToSchemaObject, showSchemaType)
+import Data.Aeson.Schema.Internal (showSchemaType)
+import Data.Aeson.Schema.Type (ToSchemaObject)
 import TestUtils (mkExpQQ)
 import TestUtils.DeepSeq ()
 

--- a/test/Tests/UnwrapQQ.hs
+++ b/test/Tests/UnwrapQQ.hs
@@ -72,10 +72,7 @@ testInvalidUnwrapDefs = testGroup "Invalid unwrap definitions"
       [unwrapErr| FooSchema.asdf |] @?= "Unknown schema: FooSchema"
 
   , testCase "Unwrap non-schema" $
-      let msg = [unwrapErr| NotASchema.foo |]
-          isPrefixOf a b = Text.isPrefixOf (Text.pack a) (Text.pack b)
-      in assertBool ("Error message does not match: " ++ msg) $
-        "Unknown reified schema: " `isPrefixOf` msg
+      [unwrapErr| NotASchema.foo |] @?= "'Tests.UnwrapQQ.TH.NotASchema' is not a Schema"
 
   , testCase "Unwrap key on non-object" $
       [unwrapErr| ListSchema.ids.foo |] @?= "Cannot get key 'foo' in schema: SchemaList Int"
@@ -91,7 +88,7 @@ testInvalidUnwrapDefs = testGroup "Invalid unwrap definitions"
       [unwrapErr| ListSchema.foo |] @?= [r|Key 'foo' does not exist in schema: SchemaObject { "ids": List Int }|]
 
   , testCase "Unwrap list of keys with different types" $
-      [unwrapErr| ABCSchema.[a,b,c] |] @?= [r|List contains different types with schema: SchemaObject { "a": Bool, "b": Bool, "c": Double }|]
+      [unwrapErr| ABCSchema.[a,b,c] |] @?= [r|List contains different types in schema: SchemaObject { "a": Bool, "b": Bool, "c": Double }|]
 
   , testCase "Unwrap list of keys on non-object schema" $
       [unwrapErr| ListSchema.ids.[a,b] |] @?= "Cannot get keys in schema: SchemaList Int"

--- a/test/Tests/UnwrapQQ/TH.hs
+++ b/test/Tests/UnwrapQQ/TH.hs
@@ -35,6 +35,8 @@ type MySchema = [schema|
 
 type MySchemaResult = Object MySchema
 
+type NotASchema = Int
+
 -- Compile above types before reifying
 $(return [])
 
@@ -46,7 +48,7 @@ qState = QState
       , ("MaybeSchema", ''MaybeSchema)
       , ("SumSchema", ''SumSchema)
       , ("ABCSchema", ''ABCSchema)
-      , ("NotASchema", ''Maybe)
+      , ("NotASchema", ''NotASchema)
       , ("MySchemaResult", ''MySchemaResult)
       ]
   , reifyInfo = $(
@@ -55,7 +57,7 @@ qState = QState
         , ''MaybeSchema
         , ''SumSchema
         , ''ABCSchema
-        , ''Maybe
+        , ''NotASchema
         , ''MySchema
         , ''MySchemaResult
         ]


### PR DESCRIPTION
Instead of two separate `SchemaType` types (one in `Schema.Internal`, one in `Schema.Show`), we'll have one `SchemaType'` parametrized type. Same for `SchemaKey` (one in `Schema.Internal`, one in `Schema.Key`).

With this consolidation, we can refactor quasiquoters like `schema`, where instead of going directly from `parsed value -> TypeQ`, we'll go `parsed value -> SchemaV -> TypeQ`, which will give us more power in inspecting things.

This does result in a slight decrease in performance due to the intermediate step, and also because we're now reifying included schemas rather than just passing them along. But we get the ability to implement features that would be difficult to do before. For example, we can't currently `unwrap` into an included schema, but now we can, treating an included schema as more of a shortcut for copy/paste and less of a special case.