### PR TITLE
Fix referencing a schema using a non-imported type

### DIFF
--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0a280b82e6601cb4654595d662ca409cf54c96d31925d0281548019af6a4582d
+-- hash: fd5f702f863b44ade602f91e5357c4eb8012976e65e943b49834155ac289488a
 
 name:           aeson-schemas
 version:        1.2.0
@@ -125,6 +125,7 @@ test-suite aeson-schemas-test
     , tasty-quickcheck
     , template-haskell >=2.12.0.0 && <2.17
     , text >=1.2.2.2 && <1.3
+    , th-orphans
     , th-test-utils
     , unordered-containers >=0.2.8.0 && <0.3
   if impl(ghc >= 8.0)

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ tests:
       - tasty-hunit
       - tasty-golden
       - tasty-quickcheck
+      - th-orphans
       - th-test-utils
 
 benchmarks:

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -28,7 +28,8 @@ import Data.Aeson.Schema.TH.Parse
     (SchemaDef(..), SchemaDefObjItem(..), SchemaDefObjKey(..), parseSchemaDef)
 import Data.Aeson.Schema.TH.Utils (reifySchema, schemaVToTypeQ)
 import Data.Aeson.Schema.Type
-    ( Schema'(..)
+    ( NameLike(..)
+    , Schema'(..)
     , SchemaObjectMapV
     , SchemaType'(..)
     , SchemaTypeV
@@ -174,7 +175,7 @@ fromSchemaDefKey = \case
 
 fromSchemaDefType :: SchemaDef -> Q SchemaTypeV
 fromSchemaDefType = \case
-  SchemaDefType other    -> return $ SchemaScalar other
+  SchemaDefType name     -> return $ SchemaScalar $ NameRef name
   SchemaDefMaybe inner   -> SchemaMaybe <$> fromSchemaDefType inner
   SchemaDefTry inner     -> SchemaTry <$> fromSchemaDefType inner
   SchemaDefList inner    -> SchemaList <$> fromSchemaDefType inner

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -86,7 +86,7 @@ reifySchemaName = reifySchemaType >=> parseSchema
     parseSchemaType :: TypeWithoutKinds -> Maybe SchemaTypeV
     parseSchemaType = \case
       AppT (PromotedT name) (ConT inner)
-        | name == 'SchemaScalar -> Just $ SchemaScalar $ NameRef $ nameBase inner
+        | name == 'SchemaScalar -> Just $ SchemaScalar $ NameTH inner
 
       AppT (PromotedT name) inner
         | name == 'SchemaMaybe  -> SchemaMaybe <$> parseSchemaType inner
@@ -135,6 +135,7 @@ resolveName = \case
   NameRef "Text"   -> pure ''Text
 
   NameRef name     -> getType name
+  NameTH name      -> pure name
   where
     getType :: String -> Q Name
     getType ty = maybe (fail $ "Unknown type: " ++ ty) pure =<< lookupTypeName ty

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -119,12 +119,12 @@ schemaObjectMapVToTypeQ = promotedListT . map schemaObjectPairVToTypeQ
 
 schemaTypeVToTypeQ :: SchemaTypeV -> TypeQ
 schemaTypeVToTypeQ = \case
-  SchemaScalar name     -> [t| 'SchemaScalar $(resolveName name >>= conT) |]
-  SchemaMaybe inner     -> [t| 'SchemaMaybe $(schemaTypeVToTypeQ inner) |]
-  SchemaTry inner       -> [t| 'SchemaTry $(schemaTypeVToTypeQ inner) |]
-  SchemaList inner      -> [t| 'SchemaList $(schemaTypeVToTypeQ inner) |]
-  SchemaUnion schemas   -> [t| 'SchemaUnion $(promotedListT $ map schemaTypeVToTypeQ schemas) |]
-  SchemaObject pairs    -> [t| 'SchemaObject $(schemaObjectMapVToTypeQ pairs) |]
+  SchemaScalar name   -> [t| 'SchemaScalar $(resolveName name >>= conT) |]
+  SchemaMaybe inner   -> [t| 'SchemaMaybe $(schemaTypeVToTypeQ inner) |]
+  SchemaTry inner     -> [t| 'SchemaTry $(schemaTypeVToTypeQ inner) |]
+  SchemaList inner    -> [t| 'SchemaList $(schemaTypeVToTypeQ inner) |]
+  SchemaUnion schemas -> [t| 'SchemaUnion $(promotedListT $ map schemaTypeVToTypeQ schemas) |]
+  SchemaObject pairs  -> [t| 'SchemaObject $(schemaObjectMapVToTypeQ pairs) |]
 
 resolveName :: NameLike -> Q Name
 resolveName = \case
@@ -134,11 +134,9 @@ resolveName = \case
   NameRef "Double" -> pure ''Double
   NameRef "Text"   -> pure ''Text
 
-  NameRef name     -> getType name
+  -- general cases
+  NameRef name     -> lookupTypeName name >>= maybe (fail $ "Unknown type: " ++ name) pure
   NameTH name      -> pure name
-  where
-    getType :: String -> Q Name
-    getType ty = maybe (fail $ "Unknown type: " ++ ty) pure =<< lookupTypeName ty
 
 {- TH utilities -}
 

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -27,7 +27,8 @@ import Language.Haskell.TH
 import Data.Aeson.Schema.Internal (Object)
 import Data.Aeson.Schema.Key (SchemaKey'(..), SchemaKeyV)
 import Data.Aeson.Schema.Type
-    ( Schema'(..)
+    ( NameLike(..)
+    , Schema'(..)
     , SchemaObjectMapV
     , SchemaType'(..)
     , SchemaTypeV
@@ -85,7 +86,7 @@ reifySchemaName = reifySchemaType >=> parseSchema
     parseSchemaType :: TypeWithoutKinds -> Maybe SchemaTypeV
     parseSchemaType = \case
       AppT (PromotedT name) (ConT inner)
-        | name == 'SchemaScalar -> Just $ SchemaScalar $ nameBase inner
+        | name == 'SchemaScalar -> Just $ SchemaScalar $ NameRef $ nameBase inner
 
       AppT (PromotedT name) inner
         | name == 'SchemaMaybe  -> SchemaMaybe <$> parseSchemaType inner
@@ -118,20 +119,25 @@ schemaObjectMapVToTypeQ = promotedListT . map schemaObjectPairVToTypeQ
 
 schemaTypeVToTypeQ :: SchemaTypeV -> TypeQ
 schemaTypeVToTypeQ = \case
-  -- some hardcoded cases
-  SchemaScalar "Bool"   -> [t| 'SchemaScalar Bool |]
-  SchemaScalar "Int"    -> [t| 'SchemaScalar Int |]
-  SchemaScalar "Double" -> [t| 'SchemaScalar Double |]
-  SchemaScalar "Text"   -> [t| 'SchemaScalar Text |]
-  SchemaScalar other    -> [t| 'SchemaScalar $(getType other) |]
+  SchemaScalar name     -> [t| 'SchemaScalar $(resolveName name >>= conT) |]
   SchemaMaybe inner     -> [t| 'SchemaMaybe $(schemaTypeVToTypeQ inner) |]
   SchemaTry inner       -> [t| 'SchemaTry $(schemaTypeVToTypeQ inner) |]
   SchemaList inner      -> [t| 'SchemaList $(schemaTypeVToTypeQ inner) |]
   SchemaUnion schemas   -> [t| 'SchemaUnion $(promotedListT $ map schemaTypeVToTypeQ schemas) |]
   SchemaObject pairs    -> [t| 'SchemaObject $(schemaObjectMapVToTypeQ pairs) |]
+
+resolveName :: NameLike -> Q Name
+resolveName = \case
+  -- some hardcoded cases
+  NameRef "Bool"   -> pure ''Bool
+  NameRef "Int"    -> pure ''Int
+  NameRef "Double" -> pure ''Double
+  NameRef "Text"   -> pure ''Text
+
+  NameRef name     -> getType name
   where
-    getType :: String -> TypeQ
-    getType ty = maybe (fail $ "Unknown type: " ++ ty) conT =<< lookupTypeName ty
+    getType :: String -> Q Name
+    getType ty = maybe (fail $ "Unknown type: " ++ ty) pure =<< lookupTypeName ty
 
 {- TH utilities -}
 

--- a/src/Data/Aeson/Schema/Type.hs
+++ b/src/Data/Aeson/Schema/Type.hs
@@ -39,7 +39,7 @@ import Data.List (intercalate)
 import Data.Proxy (Proxy(..))
 import Data.Typeable (Typeable, tyConName, typeRep, typeRepTyCon)
 import GHC.TypeLits (Symbol)
-import Language.Haskell.TH.Syntax (Lift)
+import Language.Haskell.TH.Syntax (Lift, Name, nameBase)
 
 import Data.Aeson.Schema.Key
     (IsSchemaKey(..), SchemaKey, SchemaKey', SchemaKeyV, showSchemaKeyV)
@@ -61,13 +61,14 @@ data SchemaType' s ty
 
 type SchemaObjectMap' s ty = [(SchemaKey' s, SchemaType' s ty)]
 
-data NameLike = NameRef String
+data NameLike = NameRef String | NameTH Name
 
 instance Eq NameLike where
   ty1 == ty2 = show ty1 == show ty2
 
 instance Show NameLike where
   show (NameRef ty) = ty
+  show (NameTH ty) = nameBase ty
 
 -- | Value-level schema types.
 type SchemaV = Schema' String NameLike

--- a/test/TestUtils/Arbitrary.hs
+++ b/test/TestUtils/Arbitrary.hs
@@ -35,6 +35,7 @@ import GHC.Exts (fromList)
 import GHC.TypeLits (KnownSymbol)
 import Language.Haskell.TH (ExpQ, listE, runIO)
 import Language.Haskell.TH.Quote (QuasiQuoter(quoteType))
+import Language.Haskell.TH.Syntax (Lift)
 import Test.QuickCheck
 
 import Data.Aeson.Schema (Object, schema)
@@ -42,7 +43,8 @@ import Data.Aeson.Schema.Internal (HasSchemaResult)
 import Data.Aeson.Schema.Key
     (IsSchemaKey(..), SchemaKey, SchemaKey'(..), SchemaKeyV, toContext)
 import Data.Aeson.Schema.Type
-    ( Schema'(..)
+    ( NameLike(..)
+    , Schema'(..)
     , SchemaObjectMapV
     , SchemaType
     , SchemaType'(..)
@@ -103,6 +105,8 @@ forAllArbitraryObjects = [| \runTest ->
 
 {- Run time helpers -}
 
+deriving instance Lift NameLike
+
 genSchema' :: forall schema.
   ( ArbitrarySchema ('SchemaObject schema)
   , HasSchemaResult ('SchemaObject schema)
@@ -132,7 +136,7 @@ getSchemaTypes :: SchemaV -> [String]
 getSchemaTypes = getSchemaTypes' . toSchemaObjectV
   where
     getSchemaTypes' = \case
-      SchemaScalar s -> [s]
+      SchemaScalar name -> [show name]
       SchemaMaybe inner -> "SchemaMaybe" : getSchemaTypes' inner
       SchemaTry inner -> "SchemaTry" : getSchemaTypes' inner
       SchemaList inner -> "SchemaList" : getSchemaTypes' inner
@@ -292,10 +296,10 @@ genSchemaObject n = do
       return (PhantomKey key, schemaType)
 
     scalarSchemaTypes =
-      [ (4, pure $ SchemaScalar "Bool")
-      , (4, pure $ SchemaScalar "Int")
-      , (4, pure $ SchemaScalar "Double")
-      , (4, pure $ SchemaScalar "Text")
+      [ (4, pure $ SchemaScalar $ NameRef "Bool")
+      , (4, pure $ SchemaScalar $ NameRef "Int")
+      , (4, pure $ SchemaScalar $ NameRef "Double")
+      , (4, pure $ SchemaScalar $ NameRef "Text")
       ]
 
     nonNullableSchemaTypes =

--- a/test/TestUtils/Arbitrary.hs
+++ b/test/TestUtils/Arbitrary.hs
@@ -34,6 +34,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (fromList)
 import GHC.TypeLits (KnownSymbol)
 import Language.Haskell.TH (ExpQ, listE, runIO)
+import Language.Haskell.TH.Instances ()
 import Language.Haskell.TH.Quote (QuasiQuoter(quoteType))
 import Language.Haskell.TH.Syntax (Lift)
 import Test.QuickCheck

--- a/test/Tests/SchemaQQ.hs
+++ b/test/Tests/SchemaQQ.hs
@@ -81,6 +81,11 @@ testValidSchemas = testGroup "Valid schemas"
         [schemaRep| { user: #(Tests.SchemaQQ.TH.UserSchema) } |]
         [r| SchemaObject { "user": { "name": Text } } |]
 
+  , testCase "Object with an imported schema that uses a non-imported type" $
+      assertMatches
+        [schemaRep| { a: #SchemaWithHiddenImport } |]
+        [r| SchemaObject { "a": { "a": CBool } } |]
+
   , testCase "Object with an extended schema" $
       assertMatches
         [schemaRep| { a: Int, #ExtraSchema } |]
@@ -90,6 +95,11 @@ testValidSchemas = testGroup "Valid schemas"
       assertMatches
         [schemaRep| { a: Int, #(Tests.SchemaQQ.TH.ExtraSchema) } |]
         [r| SchemaObject { "a": Int, "extra": Text } |]
+
+  , testCase "Object with an extended schema that uses a non-imported type" $
+      assertMatches
+        [schemaRep| { #SchemaWithHiddenImport } |]
+        [r| SchemaObject { "a": CBool } |]
 
   , testCase "Object with an extended schema with a shadowed key" $
       assertMatches

--- a/test/Tests/SchemaQQ/TH.hs
+++ b/test/Tests/SchemaQQ/TH.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Tests.SchemaQQ.TH where
 
 import Control.DeepSeq (deepseq)
 import Data.Aeson (FromJSON, ToJSON)
+import Foreign.C (CBool(..))
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 import Language.Haskell.TH.TestUtils
     (MockedMode(..), QMode(..), QState(..), loadNames, runTestQ, runTestQErr)
@@ -25,6 +28,11 @@ type ExtraSchema2 = [schema| { extra: Maybe Text } |]
 newtype Status = Status Int
   deriving (Show,FromJSON,ToJSON)
 
+-- | The type referenced here should not be imported in SchemaQQ.hs nor included in 'knownNames'.
+type SchemaWithHiddenImport = [schema| { a: CBool } |]
+deriving instance ToJSON CBool
+deriving instance FromJSON CBool
+
 -- Compile above types before reifying
 $(return [])
 
@@ -38,9 +46,17 @@ qState = QState
       , ("ExtraSchema2", ''ExtraSchema2)
       , ("Tests.SchemaQQ.TH.UserSchema", ''UserSchema)
       , ("Tests.SchemaQQ.TH.ExtraSchema", ''ExtraSchema)
+      , ("SchemaWithHiddenImport", ''SchemaWithHiddenImport)
       , ("Int", ''Int)
       ]
-  , reifyInfo = $(loadNames [''UserSchema, ''ExtraSchema, ''ExtraSchema2, ''Int])
+  , reifyInfo = $(loadNames
+      [ ''UserSchema
+      , ''ExtraSchema
+      , ''ExtraSchema2
+      , ''SchemaWithHiddenImport
+      , ''Int
+      ]
+    )
   }
 
 -- | A quasiquoter for generating the string representation of a schema.


### PR DESCRIPTION
#44 broke the use-case where a schema uses an imported scalar type in module A, which is included in a schema in module B:
```hs
-- module A
import Foo.Bar (Foo)

type MySchema = [schema| { foo: Foo } |]

-- module B
-- does NOT import Foo.Bar

type MySchema2 = [schema| { a: #MySchema } |]
```
This broke because we now completely reify included schemas as if the schema were defined inline.

This PR adds a `NameLike` feature where SchemaScalars can be either a `String` (referencing a type that must be imported) or a `Name` which is persisted after reifying a SchemaScalar.