### PR TITLE
Prevent unwrapping past suffix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,10 @@ jobs:
       - run:
           name: Test
           command: |
-            STACK_ARGS=(--test)
+            STACK_ARGS=(
+              --test
+              --ta '--no-create'
+            )
             if [[ -n "${CI_LATEST}" ]]; then
               STACK_ARGS+=(--coverage)
             fi

--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0f78c113f9a0f6c530eb87322ad0934b8de31326d8718ec12464a329d611cdd8
+-- hash: 842928cde07b5e3840763172b2c2e5aa6ff65a41cde7029314196acbc016ecbf
 
 name:           aeson-schemas
 version:        1.2.0
@@ -38,10 +38,14 @@ extra-source-files:
     test/goldens/fromjson_union_invalid.golden
     test/goldens/getqq_empty_expression.golden
     test/goldens/getqq_no_operators.golden
+    test/goldens/getqq_ops_after_list.golden
+    test/goldens/getqq_ops_after_tuple.golden
     test/goldens/README_Quickstart.golden
     test/goldens/schemaqq_key_with_invalid_character.golden
     test/goldens/schemaqq_key_with_trailing_escape.golden
     test/goldens/sumtype_decode_invalid.golden
+    test/goldens/unwrapqq_unwrap_past_list.golden
+    test/goldens/unwrapqq_unwrap_past_tuple.golden
 
 source-repository head
   type: git

--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fd5f702f863b44ade602f91e5357c4eb8012976e65e943b49834155ac289488a
+-- hash: 0f78c113f9a0f6c530eb87322ad0934b8de31326d8718ec12464a329d611cdd8
 
 name:           aeson-schemas
 version:        1.2.0
@@ -36,7 +36,11 @@ extra-source-files:
     test/goldens/fromjson_phantom_invalid.golden
     test/goldens/fromjson_scalar_invalid.golden
     test/goldens/fromjson_union_invalid.golden
+    test/goldens/getqq_empty_expression.golden
+    test/goldens/getqq_no_operators.golden
     test/goldens/README_Quickstart.golden
+    test/goldens/schemaqq_key_with_invalid_character.golden
+    test/goldens/schemaqq_key_with_trailing_escape.golden
     test/goldens/sumtype_decode_invalid.golden
 
 source-repository head

--- a/src/Data/Aeson/Schema/TH/Get.hs
+++ b/src/Data/Aeson/Schema/TH/Get.hs
@@ -139,7 +139,7 @@ fromJust msg = Maybe.fromMaybe (error errMsg)
 (<$:>) :: (a -> b) -> [a] -> [b]
 (<$:>) = (<$>)
 
-showGetterOps :: [GetterOperation] -> String
+showGetterOps :: Foldable t => t GetterOperation -> String
 showGetterOps = concatMap showGetterOp
   where
     showGetterOp = \case
@@ -148,5 +148,7 @@ showGetterOps = concatMap showGetterOp
       GetterMapList -> "[]"
       GetterMapMaybe -> "?"
       GetterBranch x -> '@' : show x
-      GetterList elemOps -> ".[" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ "]"
-      GetterTuple elemOps -> ".(" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ ")"
+      GetterList elemOps -> ".[" ++ showGetterOpsList elemOps ++ "]"
+      GetterTuple elemOps -> ".(" ++ showGetterOpsList elemOps ++ ")"
+
+    showGetterOpsList = intercalate "," . NonEmpty.toList . fmap showGetterOps

--- a/src/Data/Aeson/Schema/TH/Get.hs
+++ b/src/Data/Aeson/Schema/TH/Get.hs
@@ -117,14 +117,14 @@ generateGetterExp GetterExp{..} = maybe expr (appE expr . varE . mkName) start
             let proxyCon = [| Proxy |]
                 proxyType = [t| Proxy $(litT $ strTyLit key) |]
             in applyToNext' $ Right $ appE [| getKey |] $ sigE proxyCon proxyType
-          GetterList elemOps  -> checkLast ".[*]" >> applyToEach' listE elemOps
-          GetterTuple elemOps -> checkLast ".(*)" >> applyToEach' tupE elemOps
           GetterBang          -> applyToNext' $ Right [| fromJust $(lift fromJustMsg) |]
           GetterMapMaybe      -> applyToNext' $ Left [| (<$?>) |]
           GetterMapList       -> applyToNext' $ Left [| (<$:>) |]
           GetterBranch branch ->
             let branchTyLit = litT $ numTyLit $ fromIntegral branch
             in applyToNext' $ Right [| fromSumType (Proxy :: Proxy $branchTyLit) |]
+          GetterList elemOps  -> checkLast ".[*]" >> applyToEach' listE elemOps
+          GetterTuple elemOps -> checkLast ".(*)" >> applyToEach' tupE elemOps
 
 -- | fromJust with helpful error message
 fromJust :: HasCallStack => String -> Maybe a -> a
@@ -145,9 +145,9 @@ showGetterOps = concatMap showGetterOp
   where
     showGetterOp = \case
       GetterKey key -> '.':key
-      GetterList elemOps -> ".[" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ "]"
-      GetterTuple elemOps -> ".(" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ ")"
       GetterBang -> "!"
       GetterMapList -> "[]"
       GetterMapMaybe -> "?"
       GetterBranch x -> '@' : show x
+      GetterList elemOps -> ".[" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ "]"
+      GetterTuple elemOps -> ".(" ++ intercalate "," (map (showGetterOps . NonEmpty.toList) $ NonEmpty.toList elemOps) ++ ")"

--- a/src/Data/Aeson/Schema/TH/Get.hs
+++ b/src/Data/Aeson/Schema/TH/Get.hs
@@ -13,7 +13,7 @@ The 'get' quasiquoter.
 
 module Data.Aeson.Schema.TH.Get where
 
-import Control.Monad (unless, (>=>))
+import Control.Monad ((>=>))
 import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
@@ -110,7 +110,6 @@ generateGetterExp GetterExp{..} = maybe expr (appE expr . varE . mkName) start
       op:ops ->
         let applyToNext' = applyToNext $ mkGetterExp (op:history) ops
             applyToEach' = applyToEach history
-            checkLast label = unless (null ops) $ fail $ label ++ " operation MUST be last."
             fromJustMsg = startDisplay ++ showGetterOps (reverse history)
         in case op of
           GetterKey key       ->
@@ -123,8 +122,8 @@ generateGetterExp GetterExp{..} = maybe expr (appE expr . varE . mkName) start
           GetterBranch branch ->
             let branchTyLit = litT $ numTyLit $ fromIntegral branch
             in applyToNext' $ Right [| fromSumType (Proxy :: Proxy $branchTyLit) |]
-          GetterList elemOps  -> checkLast ".[*]" >> applyToEach' listE elemOps
-          GetterTuple elemOps -> checkLast ".(*)" >> applyToEach' tupE elemOps
+          GetterList elemOps  -> applyToEach' listE elemOps
+          GetterTuple elemOps -> applyToEach' tupE elemOps
 
 -- | fromJust with helpful error message
 fromJust :: HasCallStack => String -> Maybe a -> a

--- a/src/Data/Aeson/Schema/TH/Parse.hs
+++ b/src/Data/Aeson/Schema/TH/Parse.hs
@@ -138,12 +138,13 @@ parseGetterOps = some parseGetterOp
 
 data GetterOperation
   = GetterKey String
-  | GetterList (NonEmpty GetterOps)
-  | GetterTuple (NonEmpty GetterOps)
   | GetterBang
   | GetterMapList
   | GetterMapMaybe
   | GetterBranch Int
+  -- suffixes
+  | GetterList (NonEmpty GetterOps)
+  | GetterTuple (NonEmpty GetterOps)
   deriving (Show)
 
 parseGetterOp :: Parser GetterOperation

--- a/src/Data/Aeson/Schema/TH/Parse.hs
+++ b/src/Data/Aeson/Schema/TH/Parse.hs
@@ -12,17 +12,17 @@ Definitions for parsing input text in QuasiQuoters.
 
 module Data.Aeson.Schema.TH.Parse where
 
-#if !MIN_VERSION_megaparsec(6,4,0)
-import Control.Applicative (empty)
-#endif
-import Control.Monad (void)
+import Control.Monad (MonadPlus, void)
 #if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
 #endif
 import Data.Functor (($>))
 import Data.List (intercalate)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Void (Void)
-import Text.Megaparsec
+import Text.Megaparsec hiding (sepBy1, sepEndBy1, some)
+import qualified Text.Megaparsec as Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
@@ -44,8 +44,8 @@ data SchemaDef
   | SchemaDefTry SchemaDef
   | SchemaDefList SchemaDef
   | SchemaDefInclude String
-  | SchemaDefObj [SchemaDefObjItem] -- ^ Invariant: non-empty
-  | SchemaDefUnion [SchemaDef] -- ^ Invariant: non-empty
+  | SchemaDefObj (NonEmpty SchemaDefObjItem)
+  | SchemaDefUnion (NonEmpty SchemaDef)
   deriving (Show)
 
 data SchemaDefObjItem
@@ -67,8 +67,9 @@ parseSchemaDef = runParserFail $ do
   return def
   where
     parseSchemaDefWithUnions =
-      let parseSchemaUnion [schemaDef'] = schemaDef'
-          parseSchemaUnion schemaDefs = SchemaDefUnion schemaDefs
+      let parseSchemaUnion schemaDefs
+            | length schemaDefs == 1 = NonEmpty.head schemaDefs
+            | otherwise = SchemaDefUnion schemaDefs
       in fmap parseSchemaUnion $ parseSchemaDefWithoutUnions `sepBy1` lexeme "|"
 
     parseSchemaDefWithoutUnions = choice
@@ -100,14 +101,14 @@ parseSchemaDef = runParserFail $ do
 
 data GetterExp = GetterExp
   { start     :: Maybe String
-  , getterOps :: GetterOps -- ^ Invariant: non-empty
+  , getterOps :: GetterOps
   } deriving (Show)
 
 parseGetterExp :: MonadFail m => String -> m GetterExp
 parseGetterExp = runParserFail $ do
   space
   start <- optional $ namespacedIdentifier lowerChar
-  getterOps <- some parseGetterOp
+  getterOps <- parseGetterOps
   space
   void eof
   return GetterExp{..}
@@ -116,26 +117,29 @@ parseGetterExp = runParserFail $ do
 
 data UnwrapSchema = UnwrapSchema
   { startSchema :: String
-  , getterOps   :: GetterOps -- ^ Invariant: non-empty
+  , getterOps   :: GetterOps
   } deriving (Show)
 
 parseUnwrapSchema :: MonadFail m => String -> m UnwrapSchema
 parseUnwrapSchema = runParserFail $ do
   space
   startSchema <- namespacedIdentifier upperChar
-  getterOps <- some parseGetterOp
+  getterOps <- parseGetterOps
   space
   void eof
   return UnwrapSchema{..}
 
 {- GetterOps -}
 
-type GetterOps = [GetterOperation]
+type GetterOps = NonEmpty GetterOperation
+
+parseGetterOps :: Parser GetterOps
+parseGetterOps = some parseGetterOp
 
 data GetterOperation
   = GetterKey String
-  | GetterList [GetterOps] -- ^ Invariant: non-empty
-  | GetterTuple [GetterOps] -- ^ Invariant: non-empty
+  | GetterList (NonEmpty GetterOps)
+  | GetterTuple (NonEmpty GetterOps)
   | GetterBang
   | GetterMapList
   | GetterMapMaybe
@@ -147,11 +151,11 @@ parseGetterOp = choice
   [ lexeme "!" $> GetterBang
   , lexeme "[]" $> GetterMapList
   , lexeme "?" $> GetterMapMaybe
-  , lexeme "@" *> (GetterBranch . read <$> some digitChar)
+  , lexeme "@" *> (GetterBranch . read . NonEmpty.toList <$> some digitChar)
   , optional (lexeme ".") *> choice
       [ GetterKey <$> jsonKey
-      , fmap GetterList $ between (lexeme "[") (lexeme "]") $ some parseGetterOp `sepBy1` lexeme ","
-      , fmap GetterTuple $ between (lexeme "(") (lexeme ")") $ some parseGetterOp `sepBy1` lexeme ","
+      , fmap GetterList $ between (lexeme "[") (lexeme "]") $ parseGetterOps `sepBy1` lexeme ","
+      , fmap GetterTuple $ between (lexeme "(") (lexeme ")") $ parseGetterOps `sepBy1` lexeme ","
       ]
   ]
 
@@ -188,7 +192,7 @@ jsonKey = choice [char '"' *> jsonKey' <* char '"', jsonKey']
 
 -- | A string that can be used as a JSON key.
 jsonKey' :: Parser String
-jsonKey' = some $ choice
+jsonKey' = fmap NonEmpty.toList $ some $ choice
   [ try $ char '\\' *> anySingle'
   , noneOf $ [' ', '\\', '"'] ++ schemaChars ++ getChars
   ]
@@ -203,3 +207,17 @@ jsonKey' = some $ choice
     getChars = "!?[](),.@"
     -- characters that should not indicate the start of a key when parsing 'schema' definitions
     schemaChars = ":{}#"
+
+{- Parsing utilities -}
+
+-- | Same as 'Megaparsec.some', except returns a 'NonEmpty'
+some :: MonadPlus f => f a -> f (NonEmpty a)
+some p = NonEmpty.fromList <$> Megaparsec.some p
+
+-- | Same as 'Megaparsec.sepBy1', except returns a 'NonEmpty'
+sepBy1 :: MonadPlus f => f a -> f sep -> f (NonEmpty a)
+sepBy1 p sep = NonEmpty.fromList <$> Megaparsec.sepBy1 p sep
+
+-- | Same as 'Megaparsec.sepEndBy1', except returns a 'NonEmpty'
+sepEndBy1 :: MonadPlus f => f a -> f sep -> f (NonEmpty a)
+sepEndBy1 p sep = NonEmpty.fromList <$> Megaparsec.sepEndBy1 p sep

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -20,6 +20,7 @@ import Data.Function (on)
 import Data.Hashable (Hashable)
 import qualified Data.HashMap.Strict as HashMap
 import Data.List (nubBy)
+import qualified Data.List.NonEmpty as NonEmpty
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 
@@ -100,7 +101,7 @@ schema = QuasiQuoter
   { quoteExp = error "Cannot use `schema` for Exp"
   , quoteDec = error "Cannot use `schema` for Dec"
   , quoteType = parseSchemaDef >=> \case
-      SchemaDefObj items -> generateSchemaObject items
+      SchemaDefObj items -> generateSchemaObject $ NonEmpty.toList items
       _ -> fail "`schema` definition must be an object"
   , quotePat = error "Cannot use `schema` for Pat"
   }
@@ -180,8 +181,8 @@ fromSchemaDefType = \case
   SchemaDefTry inner     -> SchemaTry <$> fromSchemaDefType inner
   SchemaDefList inner    -> SchemaList <$> fromSchemaDefType inner
   SchemaDefInclude other -> toSchemaObjectV <$> reifySchema other
-  SchemaDefUnion schemas -> SchemaUnion <$> mapM fromSchemaDefType schemas
-  SchemaDefObj items     -> SchemaObject <$> generateSchemaObjectV items
+  SchemaDefUnion schemas -> SchemaUnion <$> mapM fromSchemaDefType (NonEmpty.toList schemas)
+  SchemaDefObj items     -> SchemaObject <$> generateSchemaObjectV (NonEmpty.toList items)
 
 {- LookupMap utilities -}
 

--- a/src/Data/Aeson/Schema/TH/Unwrap.hs
+++ b/src/Data/Aeson/Schema/TH/Unwrap.hs
@@ -112,21 +112,6 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
                 Nothing -> invalid $ "Key '" ++ key ++ "' does not exist in schema"
             _ -> invalid $ "Cannot get key '" ++ key ++ "' in schema"
 
-        GetterList elemOps ->
-          case schemaType of
-            SchemaObject _ -> do
-              elemSchemas <- traverse (go schemaType . NonEmpty.toList) elemOps
-              let elemSchema = NonEmpty.head elemSchemas
-              if all (== elemSchema) elemSchemas
-                then pure $ SchemaResultList elemSchema
-                else invalid "List contains different types in schema"
-            _ -> invalid "Cannot get keys in schema"
-
-        GetterTuple elemOps ->
-          case schemaType of
-            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType . NonEmpty.toList) (NonEmpty.toList elemOps)
-            _ -> invalid "Cannot get keys in schema"
-
         GetterBang ->
           case schemaType of
             SchemaMaybe inner -> go inner ops
@@ -151,6 +136,21 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
                 then go (schemas !! branch) ops
                 else invalid "Branch out of bounds for schema"
             _ -> invalid "Cannot use `@` operator on schema"
+
+        GetterList elemOps ->
+          case schemaType of
+            SchemaObject _ -> do
+              elemSchemas <- traverse (go schemaType . NonEmpty.toList) elemOps
+              let elemSchema = NonEmpty.head elemSchemas
+              if all (== elemSchema) elemSchemas
+                then pure $ SchemaResultList elemSchema
+                else invalid "List contains different types in schema"
+            _ -> invalid "Cannot get keys in schema"
+
+        GetterTuple elemOps ->
+          case schemaType of
+            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType . NonEmpty.toList) (NonEmpty.toList elemOps)
+            _ -> invalid "Cannot get keys in schema"
 
 data UnwrapSchemaResult
   = SchemaResult SchemaTypeV

--- a/src/Data/Aeson/Schema/TH/Unwrap.hs
+++ b/src/Data/Aeson/Schema/TH/Unwrap.hs
@@ -14,6 +14,7 @@ module Data.Aeson.Schema.TH.Unwrap where
 
 import Control.Monad ((>=>))
 import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NonEmpty
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 
@@ -80,7 +81,7 @@ unwrapSchema = unwrapSchemaUsing StripFunctors
 
 -- | Unwrap the given schema by applying the given operations, using the given 'FunctorHandler'.
 unwrapSchemaUsing :: FunctorHandler -> GetterOps -> SchemaV -> TypeQ
-unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go getterOps . toSchemaObjectV
+unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go (NonEmpty.toList getterOps) . toSchemaObjectV
   where
     toResultTypeQ :: UnwrapSchemaResult -> TypeQ
     toResultTypeQ = \case
@@ -96,7 +97,7 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
                 StripFunctors -> ty
         in handleFunctor <$> toResultTypeQ schemaResult
 
-    go :: SchemaTypeV -> GetterOps -> Either String UnwrapSchemaResult
+    go :: SchemaTypeV -> [GetterOperation] -> Either String UnwrapSchemaResult
     go schemaType [] = pure $ SchemaResult schemaType
     go schemaType (op:ops) =
       let invalid message = Left $ message ++ ": " ++ showSchemaTypeV schemaType
@@ -114,8 +115,8 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
         GetterList elemOps ->
           case schemaType of
             SchemaObject _ -> do
-              elemSchemas <- mapM (go schemaType) elemOps
-              let elemSchema = head elemSchemas
+              elemSchemas <- traverse (go schemaType . NonEmpty.toList) elemOps
+              let elemSchema = NonEmpty.head elemSchemas
               if all (== elemSchema) elemSchemas
                 then pure $ SchemaResultList elemSchema
                 else invalid "List contains different types in schema"
@@ -123,7 +124,7 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
 
         GetterTuple elemOps ->
           case schemaType of
-            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType) elemOps
+            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType . NonEmpty.toList) (NonEmpty.toList elemOps)
             _ -> invalid "Cannot get keys in schema"
 
         GetterBang ->

--- a/src/Data/Aeson/Schema/TH/Unwrap.hs
+++ b/src/Data/Aeson/Schema/TH/Unwrap.hs
@@ -111,19 +111,19 @@ unwrapSchemaUsing functorHandler getterOps = either fail toResultTypeQ . flip go
                 Nothing -> invalid $ "Key '" ++ key ++ "' does not exist in schema"
             _ -> invalid $ "Cannot get key '" ++ key ++ "' in schema"
 
-        GetterList ops' ->
+        GetterList elemOps ->
           case schemaType of
             SchemaObject _ -> do
-              elemSchemas <- mapM (go schemaType) ops'
+              elemSchemas <- mapM (go schemaType) elemOps
               let elemSchema = head elemSchemas
               if all (== elemSchema) elemSchemas
                 then pure $ SchemaResultList elemSchema
                 else invalid "List contains different types in schema"
             _ -> invalid "Cannot get keys in schema"
 
-        GetterTuple ops' ->
+        GetterTuple elemOps ->
           case schemaType of
-            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType) ops'
+            SchemaObject _ -> SchemaResultTuple <$> mapM (go schemaType) elemOps
             _ -> invalid "Cannot get keys in schema"
 
         GetterBang ->

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -20,13 +22,19 @@ module TestUtils
 
 import Data.Aeson (FromJSON(..), Value, eitherDecode)
 import Data.Aeson.Types (parseEither)
+#if !MIN_VERSION_megaparsec(7,0,0)
+import Data.Char (isDigit, isSpace)
+#endif
 import Data.Proxy (Proxy(..))
 import Data.String (fromString)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import Data.Typeable (Typeable, typeRep)
 import Language.Haskell.TH (ExpQ)
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
 import Test.Tasty (TestTree)
 import Test.Tasty.Golden (goldenVsString)
+import Test.Tasty.Golden.Advanced (goldenTest)
 
 import Data.Aeson.Schema (IsSchema, Object, schema)
 import qualified Data.Aeson.Schema.Internal as Internal
@@ -78,4 +86,33 @@ testGolden name fp s = goldenVsString name ("test/goldens/" ++ fp) $ return $ fr
 
 -- | A golden test for testing parse errors.
 testParseError :: String -> FilePath -> String -> TestTree
-testParseError = testGolden
+testParseError name fp s = goldenTest name getExpected getActual cmp update
+  where
+    goldenFile = "test/goldens/" ++ fp
+    getExpected = sanitize <$> Text.readFile goldenFile
+    getActual = return $ Text.pack s
+    cmp expected actual = return $ if expected == actual
+      then Nothing
+      else Just $ "Test output was different from '" ++ goldenFile ++ "'. It was:\n" ++ Text.unpack actual
+    update = Text.writeFile goldenFile
+
+#if MIN_VERSION_megaparsec(7,0,0)
+    sanitize = id
+#else
+    -- megaparsec before version 7.0.0 doesn't display the offending lines, so we need to strip
+    -- out those lines from the golden before comparing them.
+    --
+    -- e.g.
+    --
+    --    { "a:b": Int } :1:6:
+    -- >   |
+    -- > 1 |  { "a:b": Int }
+    -- >   |      ^
+    --   unexpected ':'
+    --   expecting '"' or '\'
+    sanitize = Text.unlines . filter (not . isOffendingLine) . Text.lines
+
+    isOffendingLine line = case Text.splitOn "|" line of
+      [prefix, _] -> Text.all (\c -> isDigit c || isSpace c) prefix
+      _ -> False
+#endif

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -14,6 +14,8 @@ module TestUtils
   , parseObject
   , parseProxy
   , mkExpQQ
+  , testGolden
+  , testParseError
   ) where
 
 import Data.Aeson (FromJSON(..), Value, eitherDecode)
@@ -23,6 +25,8 @@ import Data.String (fromString)
 import Data.Typeable (Typeable, typeRep)
 import Language.Haskell.TH (ExpQ)
 import Language.Haskell.TH.Quote (QuasiQuoter(..))
+import Test.Tasty (TestTree)
+import Test.Tasty.Golden (goldenVsString)
 
 import Data.Aeson.Schema (IsSchema, Object, schema)
 import qualified Data.Aeson.Schema.Internal as Internal
@@ -66,3 +70,12 @@ mkExpQQ f = QuasiQuoter
   , quoteType = error "Cannot use this QuasiQuoter for types"
   , quoteDec = error "Cannot use this QuasiQuoter for declarations"
   }
+
+{- Tasty test trees -}
+
+testGolden :: String -> FilePath -> String -> TestTree
+testGolden name fp s = goldenVsString name ("test/goldens/" ++ fp) $ return $ fromString s
+
+-- | A golden test for testing parse errors.
+testParseError :: String -> FilePath -> String -> TestTree
+testParseError = testGolden

--- a/test/Tests/GetQQ.hs
+++ b/test/Tests/GetQQ.hs
@@ -361,10 +361,10 @@ testInvalidExpressions = testGroup "Invalid expressions"
       [getErr| |]
   , testParseError "No operators" "getqq_no_operators.golden"
       [getErr| o |]
-  , testCase "Operators after tuple of keys" $
-      [getErr| o.(a,b).foo |] @?= ".(*) operation MUST be last."
-  , testCase "Operators after list of keys" $
-      [getErr| o.[a,b].foo |] @?= ".[*] operation MUST be last."
+  , testParseError "Operators after tuple of keys" "getqq_ops_after_tuple.golden"
+      [getErr| o.(a,b).foo |]
+  , testParseError "Operators after list of keys" "getqq_ops_after_list.golden"
+      [getErr| o.[a,b].foo |]
   ]
 
 {- Helpers -}

--- a/test/Tests/GetQQ.hs
+++ b/test/Tests/GetQQ.hs
@@ -25,7 +25,7 @@ import Data.Aeson.Schema (Object, schema)
 import Data.Aeson.Schema.TH (mkEnum)
 import Data.Aeson.Schema.Utils.Sum (SumType(..))
 import Tests.GetQQ.TH
-import TestUtils (parseObject)
+import TestUtils (parseObject, testParseError)
 
 mkEnum "Greeting" ["HELLO", "GOODBYE"]
 
@@ -357,20 +357,15 @@ testNestedExpressions = testGroup "Nested expressions"
 
 testInvalidExpressions :: TestTree
 testInvalidExpressions = testGroup "Invalid expressions"
-  [ testCase "Empty expression" $
-      assertErrorContains "unexpected end of input" [getErr| |]
-  , testCase "No operators" $
-      assertErrorContains "unexpected space" [getErr| o |]
+  [ testParseError "Empty expression" "getqq_empty_expression.golden"
+      [getErr| |]
+  , testParseError "No operators" "getqq_no_operators.golden"
+      [getErr| o |]
   , testCase "Operators after tuple of keys" $
       [getErr| o.(a,b).foo |] @?= ".(*) operation MUST be last."
   , testCase "Operators after list of keys" $
       [getErr| o.[a,b].foo |] @?= ".[*] operation MUST be last."
   ]
-  where
-    assertErrorContains msg e =
-      if msg `Text.isInfixOf` Text.pack e
-        then return ()
-        else assertFailure $ "incorrect error message: " ++ e
 
 {- Helpers -}
 

--- a/test/Tests/Object/FromJSON.hs
+++ b/test/Tests/Object/FromJSON.hs
@@ -14,14 +14,12 @@ import Data.Aeson (FromJSON(..), Value)
 import Data.Aeson.QQ (aesonQQ)
 import Data.Aeson.Types (parseEither)
 import Data.Proxy (Proxy)
-import Data.String (fromString)
 import Test.Tasty
-import Test.Tasty.Golden
 import Test.Tasty.QuickCheck
 
 import Data.Aeson.Schema (Object)
 import Tests.Object.FromJSON.TH
-import TestUtils (parseProxy)
+import TestUtils (parseProxy, testGolden)
 import TestUtils.Arbitrary (ArbitraryObject(..), forAllArbitraryObjects)
 
 test :: TestTree
@@ -147,11 +145,11 @@ runTestCase = \case
         Right _ -> ()
         Left e -> error $ "Unexpected failure: " ++ e
 
-  CheckError name golden schema value ->
-    goldenVsString name ("test/goldens/" ++ golden) $
+  CheckError name fp schema value ->
+    testGolden name fp $
       case parse schema value of
         Right o -> error $ "Unexpectedly parsed: " ++ show o
-        Left e -> return $ fromString e
+        Left e -> e
 
 parse :: FromJSON a => Proxy a -> Value -> Either String a
 parse _ = parseEither parseJSON

--- a/test/Tests/UnwrapQQ.hs
+++ b/test/Tests/UnwrapQQ.hs
@@ -11,7 +11,7 @@ import Text.RawString.QQ (r)
 
 import Data.Aeson.Schema (Object, get)
 import Tests.UnwrapQQ.TH
-import TestUtils (json)
+import TestUtils (json, testParseError)
 
 test :: TestTree
 test = testGroup "`unwrap` quasiquoter"
@@ -94,8 +94,14 @@ testInvalidUnwrapDefs = testGroup "Invalid unwrap definitions"
   , testCase "Unwrap list of keys on non-object schema" $
       [unwrapErr| ListSchema.ids.[a,b] |] @?= "Cannot get keys in schema: SchemaList Int"
 
+  , testParseError "Unwrap beyond list of keys" "unwrapqq_unwrap_past_list.golden"
+      [unwrapErr| ABCSchema.[a,b].foo |]
+
   , testCase "Unwrap tuple of keys on non-object schema" $
       [unwrapErr| ListSchema.ids.(a,b) |] @?= "Cannot get keys in schema: SchemaList Int"
+
+  , testParseError "Unwrap beyond tuple of keys" "unwrapqq_unwrap_past_tuple.golden"
+      [unwrapErr| ABCSchema.(a,b).foo |]
 
   , testCase "Unwrap branch on non-branch" $
       [unwrapErr| MaybeSchema.class@0 |] @?= "Cannot use `@` operator on schema: SchemaMaybe Text"

--- a/test/goldens/getqq_empty_expression.golden
+++ b/test/goldens/getqq_empty_expression.golden
@@ -2,5 +2,4 @@
   |
 1 |  
   |  ^
-unexpected end of input
 expecting "[]", '!', '"', '(', '.', '?', '@', '[', '\', lowercase letter, or white space

--- a/test/goldens/getqq_empty_expression.golden
+++ b/test/goldens/getqq_empty_expression.golden
@@ -1,0 +1,6 @@
+ :1:2:
+  |
+1 |  
+  |  ^
+unexpected end of input
+expecting "[]", '!', '"', '(', '.', '?', '@', '[', '\', lowercase letter, or white space

--- a/test/goldens/getqq_no_operators.golden
+++ b/test/goldens/getqq_no_operators.golden
@@ -1,0 +1,6 @@
+ o :1:3:
+  |
+1 |  o 
+  |   ^
+unexpected space
+expecting "[]", '!', '"', ''', '(', '.', '?', '@', '[', '\', or alphanumeric character

--- a/test/goldens/getqq_no_operators.golden
+++ b/test/goldens/getqq_no_operators.golden
@@ -2,5 +2,4 @@
   |
 1 |  o 
   |   ^
-unexpected space
 expecting "[]", '!', '"', ''', '(', '.', '?', '@', '[', '\', or alphanumeric character

--- a/test/goldens/getqq_ops_after_list.golden
+++ b/test/goldens/getqq_ops_after_list.golden
@@ -1,0 +1,6 @@
+ o.[a,b].foo :1:9:
+  |
+1 |  o.[a,b].foo 
+  |         ^
+unexpected '.'
+expecting end of input or white space

--- a/test/goldens/getqq_ops_after_tuple.golden
+++ b/test/goldens/getqq_ops_after_tuple.golden
@@ -1,0 +1,6 @@
+ o.(a,b).foo :1:9:
+  |
+1 |  o.(a,b).foo 
+  |         ^
+unexpected '.'
+expecting end of input or white space

--- a/test/goldens/schemaqq_key_with_invalid_character.golden
+++ b/test/goldens/schemaqq_key_with_invalid_character.golden
@@ -1,0 +1,6 @@
+ { "a:b": Int } :1:6:
+  |
+1 |  { "a:b": Int } 
+  |      ^
+unexpected ':'
+expecting '"' or '\'

--- a/test/goldens/schemaqq_key_with_trailing_escape.golden
+++ b/test/goldens/schemaqq_key_with_trailing_escape.golden
@@ -1,0 +1,6 @@
+ { "a\": Int } :1:8:
+  |
+1 |  { "a\": Int } 
+  |        ^
+unexpected ':'
+expecting '"' or '\'

--- a/test/goldens/unwrapqq_unwrap_past_list.golden
+++ b/test/goldens/unwrapqq_unwrap_past_list.golden
@@ -1,0 +1,6 @@
+ ABCSchema.[a,b].foo :1:17:
+  |
+1 |  ABCSchema.[a,b].foo 
+  |                 ^
+unexpected '.'
+expecting end of input or white space

--- a/test/goldens/unwrapqq_unwrap_past_tuple.golden
+++ b/test/goldens/unwrapqq_unwrap_past_tuple.golden
@@ -1,0 +1,6 @@
+ ABCSchema.(a,b).foo :1:17:
+  |
+1 |  ABCSchema.(a,b).foo 
+  |                 ^
+unexpected '.'
+expecting end of input or white space


### PR DESCRIPTION
We already check that the following is invalid:
```hs
[get| o.[x, y].foo |]
```
We should also be checking it for `unwrap`:
```hs
[unwrap| MySchema.[x, y].foo |]
```
This PR makes it a parse error instead of manually checking it in the `get` quasiquoter