### PR TITLE
Optimize including schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming
 
+## 1.3.2
+
 Performance:
 
 * Optimized including other schemas in a schema, which previously caused a huge slowdown, and possibly even out-of-memory errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+Performance:
+
+* Optimized including other schemas in a schema, which previously caused a huge slowdown, and possibly even out-of-memory errors.
+
 ## 1.3.1
 
 Bug fixes:

--- a/aeson-schemas.cabal
+++ b/aeson-schemas.cabal
@@ -4,10 +4,10 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6e5e2eab50589f9f99c1387da0ff4621c7207230421a5d8212fc685a0ec54150
+-- hash: f878fea8c59bc8e0ba2ad6e3624a633b30cde5f6dba00bc63ed4c4777ac808f7
 
 name:           aeson-schemas
-version:        1.3.1
+version:        1.3.2
 synopsis:       Easily consume JSON data on-demand with type-safety
 description:    Parse JSON data easily and safely without defining new data types. Useful
                 for deeply nested JSON data, which is difficult to parse using the default

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aeson-schemas
-version: 1.3.1
+version: 1.3.2
 verbatim:
   cabal-version: '>= 1.10'
 license: BSD3

--- a/src/Data/Aeson/Schema/TH/Schema.hs
+++ b/src/Data/Aeson/Schema/TH/Schema.hs
@@ -36,7 +36,6 @@ import Data.Aeson.Schema.Type
     , SchemaTypeV
     , fromSchemaV
     , showSchemaTypeV
-    , toSchemaObjectV
     )
 import Data.Aeson.Schema.Utils.Invariant (unreachable)
 import Data.Aeson.Schema.Utils.NameLike (NameLike(..))
@@ -147,6 +146,7 @@ getSchemaObjectMap = \case
       SchemaTry _ -> True -- even if inner is a non-object schema, it'll still parse to be Nothing
       SchemaUnion schemas -> any isValidPhantomSchema schemas
       SchemaObject _ -> True
+      SchemaInclude _ -> True
       _ -> False
 
 -- | Resolve the given keys with the following rules:
@@ -181,7 +181,7 @@ fromSchemaDefType = \case
   SchemaDefMaybe inner   -> SchemaMaybe <$> fromSchemaDefType inner
   SchemaDefTry inner     -> SchemaTry <$> fromSchemaDefType inner
   SchemaDefList inner    -> SchemaList <$> fromSchemaDefType inner
-  SchemaDefInclude other -> toSchemaObjectV <$> reifySchema other
+  SchemaDefInclude other -> return $ SchemaInclude $ Left $ NameRef other
   SchemaDefUnion schemas -> SchemaUnion . NonEmpty.toList <$> mapM fromSchemaDefType schemas
   SchemaDefObj items     -> SchemaObject <$> generateSchemaObjectV items
 

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -17,6 +17,7 @@ module Data.Aeson.Schema.TH.Utils
   ( reifySchema
   , lookupSchema
   , loadSchema
+  , resolveSchemaType
   , schemaVToTypeQ
   , schemaTypeVToTypeQ
   ) where
@@ -35,6 +36,7 @@ import Data.Aeson.Schema.Type
     , SchemaTypeV
     , SchemaV
     , fromSchemaV
+    , toSchemaObjectV
     )
 import Data.Aeson.Schema.Utils.Invariant (unreachable)
 import Data.Aeson.Schema.Utils.NameLike (NameLike(..), resolveName)
@@ -145,6 +147,13 @@ loadSchema ReifiedSchema{reifiedSchemaType} =
         -> return $ SchemaInclude $ Left $ NameTH inner
 
       _ -> empty
+
+-- | Resolve SchemaInclude, if present. (Not recursive)
+resolveSchemaType :: SchemaTypeV -> Q SchemaTypeV
+resolveSchemaType = \case
+  SchemaInclude (Left name) -> fmap toSchemaObjectV . loadSchema =<< lookupSchema name
+  SchemaInclude (Right _) -> unreachable "Found 'SchemaInclude Right' when resolving schema type"
+  schemaType -> pure schemaType
 
 {- Splicing schema into TH -}
 

--- a/src/Data/Aeson/Schema/TH/Utils.hs
+++ b/src/Data/Aeson/Schema/TH/Utils.hs
@@ -43,8 +43,9 @@ import Data.Aeson.Schema.Utils.NameLike (NameLike(..), resolveName)
 reifySchema :: String -> Q SchemaV
 reifySchema name = lookupSchema (NameRef name) >>= loadSchema
 
-newtype ReifiedSchema = ReifiedSchema
-  { reifiedSchemaType :: TypeWithoutKinds
+data ReifiedSchema = ReifiedSchema
+  { reifiedSchemaName :: Name
+  , reifiedSchemaType :: TypeWithoutKinds
   }
 
 -- | Look up a schema with the given name. Errors if the name doesn't exist or if the name does
@@ -52,7 +53,7 @@ newtype ReifiedSchema = ReifiedSchema
 lookupSchema :: NameLike -> Q ReifiedSchema
 lookupSchema nameLike = do
   name <- lookupSchemaName nameLike
-  ReifiedSchema <$> reifySchemaType name
+  ReifiedSchema name <$> reifySchemaType name
   where
     lookupSchemaName = \case
       NameRef name -> lookupTypeName name >>= maybe (fail $ "Unknown schema: " ++ name) return

--- a/src/Data/Aeson/Schema/Type.hs
+++ b/src/Data/Aeson/Schema/Type.hs
@@ -8,11 +8,13 @@ Defines SchemaType, the AST that defines a JSON schema.
 -}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.Aeson.Schema.Type
   ( Schema'(..)
@@ -42,6 +44,7 @@ import GHC.TypeLits (Symbol)
 import Data.Aeson.Schema.Key
     (IsSchemaKey(..), SchemaKey, SchemaKey', SchemaKeyV, showSchemaKeyV)
 import Data.Aeson.Schema.Utils.All (All(..))
+import Data.Aeson.Schema.Utils.Invariant (unreachable)
 import Data.Aeson.Schema.Utils.NameLike (NameLike(..), fromName)
 
 -- | The schema definition for a JSON object.
@@ -56,6 +59,12 @@ data SchemaType' s ty
   | SchemaList (SchemaType' s ty)
   | SchemaUnion [SchemaType' s ty] -- ^ @since v1.1.0
   | SchemaObject (SchemaObjectMap' s ty)
+  | SchemaInclude (Either ty (Schema' s ty))
+    -- ^ An optimization for including schemas.
+    --
+    -- Will always be 'Left' when used in a value-level schema and 'Right' when used in
+    -- a type-level schema. We can't use a type parameter for this because type synonyms
+    -- can't be recursive (e.g. `type Schema = Schema' Symbol Type Schema`).
   deriving (Show, Eq)
 
 type SchemaObjectMap' s ty = [(SchemaKey' s, SchemaType' s ty)]
@@ -85,6 +94,7 @@ showSchemaTypeV schema = case schema of
   SchemaList inner -> "SchemaList " ++ showSchemaTypeV' inner
   SchemaUnion _ -> "SchemaUnion " ++ showSchemaTypeV' schema
   SchemaObject _ -> "SchemaObject " ++ showSchemaTypeV' schema
+  SchemaInclude _ -> "SchemaInclude " ++ showSchemaTypeV' schema
 
 showSchemaTypeV' :: SchemaTypeV -> String
 showSchemaTypeV' = \case
@@ -94,6 +104,8 @@ showSchemaTypeV' = \case
   SchemaList inner -> "List " ++ showSchemaTypeV' inner
   SchemaUnion schemas -> "( " ++ mapJoin showSchemaTypeV' " | " schemas ++ " )"
   SchemaObject pairs -> "{ " ++ mapJoin showPair ", " pairs ++ " }"
+  SchemaInclude (Left name) -> fromName name
+  SchemaInclude (Right _) -> unreachable "Found 'SchemaInclude Right' when showing schema type"
   where
     showPair (key, inner) = showSchemaKeyV key ++ ": " ++ showSchemaTypeV' inner
 
@@ -145,6 +157,9 @@ instance All IsSchemaType schemas => IsSchemaType ('SchemaUnion schemas) where
 
 instance IsSchemaObjectMap pairs => IsSchemaType ('SchemaObject pairs) where
   toSchemaTypeV _ = SchemaObject (toSchemaTypeMapV $ Proxy @pairs)
+
+instance IsSchemaObjectMap (FromSchema schema) => IsSchemaType ('SchemaInclude ('Right schema)) where
+  toSchemaTypeV _ = toSchemaObjectV $ toSchemaV $ Proxy @schema
 
 type IsSchemaObjectMap (pairs :: SchemaObjectMap) = All IsSchemaObjectPair pairs
 

--- a/src/Data/Aeson/Schema/Type.hs
+++ b/src/Data/Aeson/Schema/Type.hs
@@ -65,6 +65,8 @@ data SchemaType' s ty
     -- Will always be 'Left' when used in a value-level schema and 'Right' when used in
     -- a type-level schema. We can't use a type parameter for this because type synonyms
     -- can't be recursive (e.g. `type Schema = Schema' Symbol Type Schema`).
+    --
+    -- @since v1.3.2
   deriving (Show, Eq)
 
 type SchemaObjectMap' s ty = [(SchemaKey' s, SchemaType' s ty)]

--- a/test/TestUtils/Arbitrary.hs
+++ b/test/TestUtils/Arbitrary.hs
@@ -143,6 +143,7 @@ getSchemaTypes = getSchemaTypes' . toSchemaObjectV
       SchemaList inner -> "SchemaList" : getSchemaTypes' inner
       SchemaUnion schemas -> "SchemaUnion" : concatMap getSchemaTypes' schemas
       SchemaObject pairs -> "SchemaObject" : concatMap (getSchemaTypes' . snd) pairs
+      SchemaInclude _ -> error "ArbitraryObject unexpectedly generated a schema that includes another schema"
 
 getObjectSizes :: SchemaV -> [Int]
 getObjectSizes = getObjectSizes' . toSchemaObjectV
@@ -154,6 +155,7 @@ getObjectSizes = getObjectSizes' . toSchemaObjectV
       SchemaList inner -> getObjectSizes' inner
       SchemaUnion schemas -> concatMap getObjectSizes' schemas
       SchemaObject pairs -> length pairs : concatMap (getObjectSizes' . snd) pairs
+      SchemaInclude _ -> error "ArbitraryObject unexpectedly generated a schema that includes another schema"
 
 getObjectDepth :: SchemaV -> Int
 getObjectDepth = getObjectDepth' . toSchemaObjectV
@@ -165,6 +167,7 @@ getObjectDepth = getObjectDepth' . toSchemaObjectV
       SchemaList inner -> getObjectDepth' inner
       SchemaUnion schemas -> maximum $ map getObjectDepth' schemas
       SchemaObject pairs -> 1 + maximum (map (getObjectDepth' . snd) pairs)
+      SchemaInclude _ -> error "ArbitraryObject unexpectedly generated a schema that includes another schema"
 
 tabulate' :: String -> [String] -> Property -> Property
 #if MIN_VERSION_QuickCheck(2,12,0)

--- a/test/Tests/SchemaQQ.hs
+++ b/test/Tests/SchemaQQ.hs
@@ -86,6 +86,11 @@ testValidSchemas = testGroup "Valid schemas"
         [schemaRep| { a: #SchemaWithHiddenImport } |]
         [r| SchemaObject { "a": { "a": CBool } } |]
 
+  , testCase "Object with an imported schema that itself imports a schema" $
+      assertMatches
+        [schemaRep| { a: #WithUser } |]
+        [r| SchemaObject { "a": { "user": { "name": Text } } } |]
+
   , testCase "Object with an extended schema" $
       assertMatches
         [schemaRep| { a: Int, #ExtraSchema } |]

--- a/test/Tests/SchemaQQ/TH.hs
+++ b/test/Tests/SchemaQQ/TH.hs
@@ -34,6 +34,11 @@ deriving instance FromJSON CBool
 -- Compile above types before reifying
 $(return [])
 
+type WithUser = [schema| { user: #UserSchema } |]
+
+-- Compile above types before reifying
+$(return [])
+
 qState :: QState 'FullyMocked
 qState = QState
   { mode = MockQ
@@ -45,6 +50,7 @@ qState = QState
       , ("Tests.SchemaQQ.TH.UserSchema", ''UserSchema)
       , ("Tests.SchemaQQ.TH.ExtraSchema", ''ExtraSchema)
       , ("SchemaWithHiddenImport", ''SchemaWithHiddenImport)
+      , ("WithUser", ''WithUser)
       , ("Int", ''Int)
       ]
   , reifyInfo = $(loadNames
@@ -52,6 +58,7 @@ qState = QState
       , ''ExtraSchema
       , ''ExtraSchema2
       , ''SchemaWithHiddenImport
+      , ''WithUser
       , ''Int
       ]
     )


### PR DESCRIPTION
When building a schema, keep the type alias in the generated schema, and don't fully realize it until we need to reify it again. Making it constant time regardless of how big the included schema is.

| Include given # of schemas | `master` | PR |
| --- | --- | --- |
| 1 | 15.92 µs | 12.30 µs |
| 5 | 66.15 µs | 50.41 µs |
| 10 | 127.1 µs | 95.59 µs |
| 100 | 1860 µs | 1527 µs |

| Include schema with given # of keys | `master` | PR |
| --- | --- | --- |
| 1 | 14.13 µs | 10.26 µs |
| 5 | 27.73 µs | 10.13 µs |
| 10 | 44.07 µs | 10.29 µs |
| 100 | 343.6 µs | 10.55 µs |

This also reduces the memory usage when typechecking schemas that include other schemas. In a private project, I got the following metrics:

| `1.2.0` | `master` | PR |
| --- | --- | --- |
| 2.5 GB | 4 GB | 3 GB |

We could probably improve it more, but this PR goes a long way.

# Changes

This is the key change:

https://github.com/LeapYear/aeson-schemas/pull/60/files#diff-7850cf57b4077811008b45abad3e90c9L184-R184
```diff
-SchemaDefInclude other -> toSchemaObjectV <$> reifySchema other
+SchemaDefInclude other -> return $ SchemaInclude $ Left $ NameRef other
```

when we include a schema, we no longer reify the entire schema + inline it in this schema. Instead, we hold a reference to it. Then we reference the other schema directly when generating the type-level schema:

https://github.com/LeapYear/aeson-schemas/pull/60/files#diff-b2c04c02961d4bc662fa5d47779b7610R182
```diff
+SchemaInclude (Left name) -> [t| 'SchemaInclude ('Right $(conT . reifiedSchemaName =<< lookupSchema name)) |]
```

The type-level schema will then be changed like this:
```diff
 type MySchema = 'Schema
-  '[ '( 'NormalKey "other", ToSchemaObject OtherSchema )
+  '[ '( 'NormalKey "other", 'SchemaInclude ('Right OtherSchema) )
    ]
```
and then from the typechecker's point of view, it's reusing the already-checked `OtherSchema` type instead of resolving the type family application `ToSchemaObject OtherSchema`.